### PR TITLE
Apply an affine transformation on the raster waveform; add waveform viewer tool

### DIFF
--- a/DumpWaveform/DumpWaveform.c
+++ b/DumpWaveform/DumpWaveform.c
@@ -17,8 +17,12 @@ static void DumpXYWaveform(uint32_t resolution, uint32_t undershoot) {
     params.undershoot = undershoot;
     params.xOffset = 0;
     params.yOffset = 0;
-    params.galvoOffsetX = 0;
-    params.galvoOffsetY = 0;
+    params.xformMatrix[0] = 1;
+    params.xformMatrix[1] = 0;
+    params.xformMatrix[2] = 0;
+    params.xformMatrix[3] = 1;
+    params.xformOffsetX = 0;
+    params.xformOffsetY = 0;
 
     uint32_t totalElementsPerFrame = GetScannerWaveformSize(&params);
 

--- a/WaveformTool/README.md
+++ b/WaveformTool/README.md
@@ -1,0 +1,24 @@
+# WaveformTool
+
+Command-line tool and GUI viewer for generating and visualizing galvo scan
+waveforms.
+
+## Building WaveformTool
+
+Build the project with Meson as usual. The executable is produced at
+`builddir/WaveformTool/WaveformTool.exe`.
+
+## Waveform Viewer GUI
+
+Interactive GUI for adjusting scan parameters and viewing the resulting
+waveforms.
+
+### Running
+
+```sh
+cd WaveformTool
+uv run waveform_viewer.py
+```
+
+`uv` will automatically install the dependencies (`dearpygui`, `numpy`) on
+first run. The viewer auto-detects `WaveformTool.exe` from the build directory.

--- a/WaveformTool/WaveformTool.c
+++ b/WaveformTool/WaveformTool.c
@@ -1,0 +1,582 @@
+#include "../src/Waveform.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum WaveformType {
+    WAVEFORM_RASTER,
+    WAVEFORM_CLOCK,
+    WAVEFORM_PARK,
+    WAVEFORM_UNPARK,
+};
+
+enum OutputFormat {
+    FORMAT_AUTO,
+    FORMAT_CSV,
+    FORMAT_RAW,
+};
+
+struct Args {
+    enum WaveformType type;
+    enum OutputFormat format;
+    const char *outputFile;
+
+    uint32_t resolution;
+    uint32_t width;
+    uint32_t height;
+    uint32_t xOffset;
+    uint32_t yOffset;
+    double zoom;
+    uint32_t undershoot;
+    double xformMatrix[4];
+    double xformOffsetX;
+    double xformOffsetY;
+    int32_t xPark;
+    int32_t yPark;
+    double prevXParkVoltage;
+    double prevYParkVoltage;
+
+    int hasResolution;
+    int hasWidth;
+    int hasHeight;
+};
+
+static int ParseUint32(const char *str, const char *name, uint32_t *out) {
+    char *end;
+    unsigned long val = strtoul(str, &end, 10);
+    if (*end != '\0' || end == str) {
+        fprintf(stderr, "Error: invalid value '%s' for %s\n", str, name);
+        return 0;
+    }
+    *out = (uint32_t)val;
+    return 1;
+}
+
+static int ParseInt32(const char *str, const char *name, int32_t *out) {
+    char *end;
+    long val = strtol(str, &end, 10);
+    if (*end != '\0' || end == str) {
+        fprintf(stderr, "Error: invalid value '%s' for %s\n", str, name);
+        return 0;
+    }
+    *out = (int32_t)val;
+    return 1;
+}
+
+static int ParseDouble(const char *str, const char *name, double *out) {
+    char *end;
+    double val = strtod(str, &end);
+    if (*end != '\0' || end == str) {
+        fprintf(stderr, "Error: invalid value '%s' for %s\n", str, name);
+        return 0;
+    }
+    *out = val;
+    return 1;
+}
+
+static void PrintUsage(void) {
+    fprintf(
+        stderr,
+        "Usage: WaveformTool <type> -o <file> [options]\n"
+        "\n"
+        "Types: raster, clock, park, unpark\n"
+        "\n"
+        "Options:\n"
+        "  -o <file>                Output file (required)\n"
+        "  --format csv|raw         Override format (auto from extension)\n"
+        "  --resolution <n>         Scanner resolution\n"
+        "  --width <n>              ROI width (default: resolution)\n"
+        "  --height <n>             ROI height (default: resolution)\n"
+        "  --xoffset <n>            ROI X offset (default: 0)\n"
+        "  --yoffset <n>            ROI Y offset (default: 0)\n"
+        "  --zoom <f>               Zoom factor (default: 1.0)\n"
+        "  --undershoot <n>         Undershoot / line delay (default: 0)\n"
+        "  --tform <a,b,c,d>        Affine 2x2 matrix, row-major\n"
+        "  --tform-offset <tx,ty>   Affine translation in volts\n"
+        "  --xpark <n>              X park position (default: 0)\n"
+        "  --ypark <n>              Y park position (default: 0)\n"
+        "  --prev-xpark-voltage <f> Previous X park voltage (default: 0)\n"
+        "  --prev-ypark-voltage <f> Previous Y park voltage (default: 0)\n"
+        "\n"
+        "Required parameters:\n"
+        "  raster:       --resolution\n"
+        "  clock:        --width and --height (or --resolution)\n"
+        "  park, unpark: --resolution\n"
+        "\n"
+        "Examples:\n"
+        "  WaveformTool raster -o scan.csv --resolution 256\n"
+        "  WaveformTool raster -o scan.raw --resolution 256 --undershoot 10\n"
+        "  WaveformTool clock -o clock.csv --resolution 64 --undershoot 5\n"
+        "  WaveformTool park -o park.csv --resolution 256\n");
+}
+
+static int ParseTform(const char *str, double m[4]) {
+    char *buf = _strdup(str);
+    if (!buf) {
+        fprintf(stderr, "Error: out of memory\n");
+        return 0;
+    }
+    char *tok = strtok(buf, ",");
+    for (int i = 0; i < 4; i++) {
+        if (!tok) {
+            fprintf(stderr,
+                    "Error: --tform requires 4 comma-separated values\n");
+            free(buf);
+            return 0;
+        }
+        char *end;
+        m[i] = strtod(tok, &end);
+        if (*end != '\0' || end == tok) {
+            fprintf(stderr, "Error: invalid value '%s' in --tform\n", tok);
+            free(buf);
+            return 0;
+        }
+        tok = strtok(NULL, ",");
+    }
+    if (tok) {
+        fprintf(stderr, "Error: --tform requires exactly 4 values\n");
+        free(buf);
+        return 0;
+    }
+    free(buf);
+    return 1;
+}
+
+static int ParseTformOffset(const char *str, double *tx, double *ty) {
+    char *buf = _strdup(str);
+    if (!buf) {
+        fprintf(stderr, "Error: out of memory\n");
+        return 0;
+    }
+    char *tok = strtok(buf, ",");
+    if (!tok) {
+        fprintf(stderr,
+                "Error: --tform-offset requires 2 comma-separated values\n");
+        free(buf);
+        return 0;
+    }
+    char *end;
+    *tx = strtod(tok, &end);
+    if (*end != '\0' || end == tok) {
+        fprintf(stderr, "Error: invalid value '%s' in --tform-offset\n", tok);
+        free(buf);
+        return 0;
+    }
+    tok = strtok(NULL, ",");
+    if (!tok) {
+        fprintf(stderr,
+                "Error: --tform-offset requires 2 comma-separated values\n");
+        free(buf);
+        return 0;
+    }
+    *ty = strtod(tok, &end);
+    if (*end != '\0' || end == tok) {
+        fprintf(stderr, "Error: invalid value '%s' in --tform-offset\n", tok);
+        free(buf);
+        return 0;
+    }
+    if (strtok(NULL, ",")) {
+        fprintf(stderr, "Error: --tform-offset requires exactly 2 values\n");
+        free(buf);
+        return 0;
+    }
+    free(buf);
+    return 1;
+}
+
+static int ParseArgs(int argc, char *argv[], struct Args *args) {
+    memset(args, 0, sizeof(*args));
+    args->zoom = 1.0;
+    args->xformMatrix[0] = 1.0;
+    args->xformMatrix[1] = 0.0;
+    args->xformMatrix[2] = 0.0;
+    args->xformMatrix[3] = 1.0;
+    args->format = FORMAT_AUTO;
+
+    if (argc < 2) {
+        PrintUsage();
+        return 0;
+    }
+
+    if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
+        PrintUsage();
+        return 0;
+    }
+
+    if (strcmp(argv[1], "raster") == 0)
+        args->type = WAVEFORM_RASTER;
+    else if (strcmp(argv[1], "clock") == 0)
+        args->type = WAVEFORM_CLOCK;
+    else if (strcmp(argv[1], "park") == 0)
+        args->type = WAVEFORM_PARK;
+    else if (strcmp(argv[1], "unpark") == 0)
+        args->type = WAVEFORM_UNPARK;
+    else {
+        fprintf(stderr, "Error: unknown waveform type '%s'\n", argv[1]);
+        return 0;
+    }
+
+    for (int i = 2; i < argc; i++) {
+        if ((strcmp(argv[i], "-o") == 0) && i + 1 < argc) {
+            args->outputFile = argv[++i];
+        } else if (strcmp(argv[i], "--format") == 0 && i + 1 < argc) {
+            i++;
+            if (strcmp(argv[i], "csv") == 0)
+                args->format = FORMAT_CSV;
+            else if (strcmp(argv[i], "raw") == 0)
+                args->format = FORMAT_RAW;
+            else {
+                fprintf(stderr, "Error: unknown format '%s'\n", argv[i]);
+                return 0;
+            }
+        } else if (strcmp(argv[i], "--resolution") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--resolution", &args->resolution))
+                return 0;
+            args->hasResolution = 1;
+        } else if (strcmp(argv[i], "--width") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--width", &args->width))
+                return 0;
+            args->hasWidth = 1;
+        } else if (strcmp(argv[i], "--height") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--height", &args->height))
+                return 0;
+            args->hasHeight = 1;
+        } else if (strcmp(argv[i], "--xoffset") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--xoffset", &args->xOffset))
+                return 0;
+        } else if (strcmp(argv[i], "--yoffset") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--yoffset", &args->yOffset))
+                return 0;
+        } else if (strcmp(argv[i], "--zoom") == 0 && i + 1 < argc) {
+            if (!ParseDouble(argv[++i], "--zoom", &args->zoom))
+                return 0;
+        } else if (strcmp(argv[i], "--undershoot") == 0 && i + 1 < argc) {
+            if (!ParseUint32(argv[++i], "--undershoot", &args->undershoot))
+                return 0;
+        } else if (strcmp(argv[i], "--tform") == 0 && i + 1 < argc) {
+            if (!ParseTform(argv[++i], args->xformMatrix))
+                return 0;
+        } else if (strcmp(argv[i], "--tform-offset") == 0 && i + 1 < argc) {
+            if (!ParseTformOffset(argv[++i], &args->xformOffsetX,
+                                  &args->xformOffsetY))
+                return 0;
+        } else if (strcmp(argv[i], "--xpark") == 0 && i + 1 < argc) {
+            if (!ParseInt32(argv[++i], "--xpark", &args->xPark))
+                return 0;
+        } else if (strcmp(argv[i], "--ypark") == 0 && i + 1 < argc) {
+            if (!ParseInt32(argv[++i], "--ypark", &args->yPark))
+                return 0;
+        } else if (strcmp(argv[i], "--prev-xpark-voltage") == 0 &&
+                   i + 1 < argc) {
+            if (!ParseDouble(argv[++i], "--prev-xpark-voltage",
+                             &args->prevXParkVoltage))
+                return 0;
+        } else if (strcmp(argv[i], "--prev-ypark-voltage") == 0 &&
+                   i + 1 < argc) {
+            if (!ParseDouble(argv[++i], "--prev-ypark-voltage",
+                             &args->prevYParkVoltage))
+                return 0;
+        } else {
+            fprintf(stderr, "Error: unknown option '%s'\n", argv[i]);
+            return 0;
+        }
+    }
+
+    if (!args->outputFile) {
+        fprintf(stderr, "Error: -o <file> is required\n");
+        return 0;
+    }
+
+    switch (args->type) {
+    case WAVEFORM_RASTER:
+    case WAVEFORM_PARK:
+    case WAVEFORM_UNPARK:
+        if (!args->hasResolution) {
+            fprintf(stderr, "Error: --resolution is required for %s\n",
+                    argv[1]);
+            return 0;
+        }
+        if (!args->hasWidth)
+            args->width = args->resolution;
+        if (!args->hasHeight)
+            args->height = args->resolution;
+        break;
+    case WAVEFORM_CLOCK:
+        if (!args->hasWidth && !args->hasHeight && args->hasResolution) {
+            args->width = args->resolution;
+            args->height = args->resolution;
+            args->hasWidth = 1;
+            args->hasHeight = 1;
+        }
+        if (!args->hasWidth || !args->hasHeight) {
+            fprintf(stderr,
+                    "Error: --width and --height are required for clock "
+                    "(or use --resolution to default both)\n");
+            return 0;
+        }
+        break;
+    }
+
+    return 1;
+}
+
+static int ResolveFormat(struct Args *args) {
+    if (args->format != FORMAT_AUTO)
+        return 1;
+
+    const char *dot = strrchr(args->outputFile, '.');
+    if (dot) {
+        if (_stricmp(dot, ".csv") == 0) {
+            args->format = FORMAT_CSV;
+            return 1;
+        }
+        if (_stricmp(dot, ".raw") == 0) {
+            args->format = FORMAT_RAW;
+            return 1;
+        }
+    }
+
+    fprintf(stderr,
+            "Error: cannot determine format from extension of '%s'; "
+            "use --format csv|raw\n",
+            args->outputFile);
+    return 0;
+}
+
+static void PopulateParams(const struct Args *args,
+                           struct WaveformParams *params) {
+    params->width = args->width;
+    params->height = args->height;
+    params->resolution = args->resolution;
+    params->zoom = args->zoom;
+    params->undershoot = args->undershoot;
+    params->xOffset = args->xOffset;
+    params->yOffset = args->yOffset;
+    memcpy(params->xformMatrix, args->xformMatrix,
+           sizeof(params->xformMatrix));
+    params->xformOffsetX = args->xformOffsetX;
+    params->xformOffsetY = args->xformOffsetY;
+    params->xPark = args->xPark;
+    params->yPark = args->yPark;
+    params->prevXParkVoltage = args->prevXParkVoltage;
+    params->prevYParkVoltage = args->prevYParkVoltage;
+}
+
+static int WriteXYCsv(FILE *f, const double *xy, uint32_t n) {
+    if (fprintf(f, "x,y\n") < 0)
+        return 0;
+    for (uint32_t i = 0; i < n; i++) {
+        if (fprintf(f, "%.17g,%.17g\n", xy[i], xy[i + n]) < 0)
+            return 0;
+    }
+    return 1;
+}
+
+static int WriteXYRaw(FILE *f, const double *xy, uint32_t n) {
+    size_t total = (size_t)n * 2;
+    return fwrite(xy, sizeof(double), total, f) == total;
+}
+
+static int ExportRaster(const struct Args *args) {
+    struct WaveformParams params;
+    PopulateParams(args, &params);
+
+    uint32_t samplesPerChan = (uint32_t)GetScannerWaveformSize(&params);
+    uint32_t bufferSize = samplesPerChan * 2;
+    double *xy = malloc(sizeof(double) * bufferSize);
+    if (!xy) {
+        fprintf(stderr, "Error: out of memory\n");
+        return 0;
+    }
+
+    GenerateGalvoWaveformFrame(&params, xy);
+
+    FILE *f = fopen(args->outputFile, args->format == FORMAT_CSV ? "w" : "wb");
+    if (!f) {
+        fprintf(stderr, "Error: cannot open '%s' for writing\n",
+                args->outputFile);
+        free(xy);
+        return 0;
+    }
+
+    int ok;
+    if (args->format == FORMAT_CSV)
+        ok = WriteXYCsv(f, xy, samplesPerChan);
+    else
+        ok = WriteXYRaw(f, xy, samplesPerChan);
+
+    fclose(f);
+    free(xy);
+
+    if (!ok) {
+        fprintf(stderr, "Error: write failed\n");
+        return 0;
+    }
+
+    printf("total sample count = %lu\n", (unsigned long)bufferSize);
+    return 1;
+}
+
+static int ExportClock(const struct Args *args) {
+    struct WaveformParams params;
+    PopulateParams(args, &params);
+
+    uint32_t n = (uint32_t)GetClockWaveformSize(&params);
+    uint8_t *lineClock = malloc(n);
+    uint8_t *lineClockFLIM = malloc(n);
+    uint8_t *frameClockFLIM = malloc(n);
+    if (!lineClock || !lineClockFLIM || !frameClockFLIM) {
+        fprintf(stderr, "Error: out of memory\n");
+        free(lineClock);
+        free(lineClockFLIM);
+        free(frameClockFLIM);
+        return 0;
+    }
+
+    GenerateLineClock(&params, lineClock);
+    GenerateFLIMLineClock(&params, lineClockFLIM);
+    GenerateFLIMFrameClock(&params, frameClockFLIM);
+
+    FILE *f = fopen(args->outputFile, args->format == FORMAT_CSV ? "w" : "wb");
+    if (!f) {
+        fprintf(stderr, "Error: cannot open '%s' for writing\n",
+                args->outputFile);
+        free(lineClock);
+        free(lineClockFLIM);
+        free(frameClockFLIM);
+        return 0;
+    }
+
+    int ok = 1;
+    if (args->format == FORMAT_CSV) {
+        if (fprintf(f, "lineClock,lineClockFLIM,frameClockFLIM\n") < 0)
+            ok = 0;
+        for (uint32_t i = 0; i < n && ok; i++) {
+            if (fprintf(f, "%u,%u,%u\n", lineClock[i], lineClockFLIM[i],
+                        frameClockFLIM[i]) < 0)
+                ok = 0;
+        }
+    } else {
+        if (fwrite(lineClock, 1, n, f) != n)
+            ok = 0;
+        if (fwrite(lineClockFLIM, 1, n, f) != n)
+            ok = 0;
+        if (fwrite(frameClockFLIM, 1, n, f) != n)
+            ok = 0;
+    }
+
+    fclose(f);
+    free(lineClock);
+    free(lineClockFLIM);
+    free(frameClockFLIM);
+
+    if (!ok) {
+        fprintf(stderr, "Error: write failed\n");
+        return 0;
+    }
+
+    printf("total sample count = %lu\n", (unsigned long)n * 3);
+    return 1;
+}
+
+static int ExportPark(const struct Args *args) {
+    struct WaveformParams params;
+    PopulateParams(args, &params);
+
+    uint32_t samplesPerChan = (uint32_t)GetParkWaveformSize(&params);
+    uint32_t bufferSize = samplesPerChan * 2;
+    double *xy = malloc(sizeof(double) * bufferSize);
+    if (!xy) {
+        fprintf(stderr, "Error: out of memory\n");
+        return 0;
+    }
+
+    GenerateGalvoParkWaveform(&params, xy);
+
+    FILE *f = fopen(args->outputFile, args->format == FORMAT_CSV ? "w" : "wb");
+    if (!f) {
+        fprintf(stderr, "Error: cannot open '%s' for writing\n",
+                args->outputFile);
+        free(xy);
+        return 0;
+    }
+
+    int ok;
+    if (args->format == FORMAT_CSV)
+        ok = WriteXYCsv(f, xy, samplesPerChan);
+    else
+        ok = WriteXYRaw(f, xy, samplesPerChan);
+
+    fclose(f);
+    free(xy);
+
+    if (!ok) {
+        fprintf(stderr, "Error: write failed\n");
+        return 0;
+    }
+
+    printf("total sample count = %lu\n", (unsigned long)bufferSize);
+    return 1;
+}
+
+static int ExportUnpark(const struct Args *args) {
+    struct WaveformParams params;
+    PopulateParams(args, &params);
+
+    uint32_t samplesPerChan = (uint32_t)GetParkWaveformSize(&params);
+    uint32_t bufferSize = samplesPerChan * 2;
+    double *xy = malloc(sizeof(double) * bufferSize);
+    if (!xy) {
+        fprintf(stderr, "Error: out of memory\n");
+        return 0;
+    }
+
+    GenerateGalvoUnparkWaveform(&params, xy);
+
+    FILE *f = fopen(args->outputFile, args->format == FORMAT_CSV ? "w" : "wb");
+    if (!f) {
+        fprintf(stderr, "Error: cannot open '%s' for writing\n",
+                args->outputFile);
+        free(xy);
+        return 0;
+    }
+
+    int ok;
+    if (args->format == FORMAT_CSV)
+        ok = WriteXYCsv(f, xy, samplesPerChan);
+    else
+        ok = WriteXYRaw(f, xy, samplesPerChan);
+
+    fclose(f);
+    free(xy);
+
+    if (!ok) {
+        fprintf(stderr, "Error: write failed\n");
+        return 0;
+    }
+
+    printf("total sample count = %lu\n", (unsigned long)bufferSize);
+    return 1;
+}
+
+int main(int argc, char *argv[]) {
+    struct Args args;
+    if (!ParseArgs(argc, argv, &args))
+        return 1;
+    if (!ResolveFormat(&args))
+        return 1;
+
+    switch (args.type) {
+    case WAVEFORM_RASTER:
+        return ExportRaster(&args) ? 0 : 1;
+    case WAVEFORM_CLOCK:
+        return ExportClock(&args) ? 0 : 1;
+    case WAVEFORM_PARK:
+        return ExportPark(&args) ? 0 : 1;
+    case WAVEFORM_UNPARK:
+        return ExportUnpark(&args) ? 0 : 1;
+    }
+    return 1;
+}

--- a/WaveformTool/meson.build
+++ b/WaveformTool/meson.build
@@ -1,0 +1,15 @@
+waveformtool_src = [
+    'WaveformTool.c',
+    '../src/Waveform.c',
+]
+
+executable(
+    'WaveformTool',
+    waveformtool_src,
+    c_args: [
+        '-D_CRT_SECURE_NO_WARNINGS',
+    ],
+    dependencies: [
+        openscandevicelib_dep,
+    ],
+)

--- a/WaveformTool/waveform_viewer.py
+++ b/WaveformTool/waveform_viewer.py
@@ -180,11 +180,28 @@ def generate_unpark(
         tmp.unlink(missing_ok=True)
 
 
-def on_generate(_sender=None, _data=None):
+def sync_width_height():
     resolution = dpg.get_value("resolution")
-    use_res = dpg.get_value("size_equals_res")
-    width = resolution if use_res else dpg.get_value("width")
-    height = resolution if use_res else dpg.get_value("height")
+    linked = dpg.get_value("size_equals_res")
+    dpg.configure_item("width", max_value=resolution, max_clamped=True,
+                        enabled=not linked)
+    dpg.configure_item("height", max_value=resolution, max_clamped=True,
+                        enabled=not linked)
+    if linked:
+        dpg.set_value("width", resolution)
+        dpg.set_value("height", resolution)
+    else:
+        if dpg.get_value("width") > resolution:
+            dpg.set_value("width", resolution)
+        if dpg.get_value("height") > resolution:
+            dpg.set_value("height", resolution)
+
+
+def on_generate(_sender=None, _data=None):
+    sync_width_height()
+    resolution = dpg.get_value("resolution")
+    width = dpg.get_value("width")
+    height = dpg.get_value("height")
     x_offset = dpg.get_value("x_offset")
     y_offset = dpg.get_value("y_offset")
     zoom = dpg.get_value("zoom")
@@ -315,9 +332,7 @@ def on_generate(_sender=None, _data=None):
 
 
 def on_size_toggle(_sender=None, _data=None):
-    linked = dpg.get_value("size_equals_res")
-    dpg.configure_item("width", enabled=not linked)
-    dpg.configure_item("height", enabled=not linked)
+    sync_width_height()
     on_generate()
 
 

--- a/WaveformTool/waveform_viewer.py
+++ b/WaveformTool/waveform_viewer.py
@@ -283,6 +283,20 @@ def on_generate(_sender=None, _data=None):
         dpg.set_value("clk_line_flim", [[], []])
         dpg.set_value("clk_frame_flim", [[], []])
 
+    # Raster rectangle corners
+    a, b, c, d = tform
+    tx, ty = tform_offset
+    xs = (-0.5 * resolution + x_offset) / (zoom * resolution)
+    ys = (-0.5 * resolution + y_offset) / (zoom * resolution)
+    xe = xs + width / (zoom * resolution)
+    ye = ys + height / (zoom * resolution)
+    corners_pre = [(xs, ys), (xe, ys), (xe, ye), (xs, ye)]
+    corners = [(a * cx + b * cy + tx, c * cx + d * cy + ty)
+               for cx, cy in corners_pre]
+    rect_x = [p[0] for p in corners] + [corners[0][0]]
+    rect_y = [p[1] for p in corners] + [corners[0][1]]
+    dpg.set_value("xy_rect", [rect_x, rect_y])
+
     for ax in ("x_ax_x", "x_ax_y", "y_ax_x", "y_ax_y",
                "xy_ax_x", "xy_ax_y", "clk_ax_x", "clk_ax_y"):
         dpg.fit_axis_data(ax)
@@ -311,6 +325,7 @@ def on_size_toggle(_sender=None, _data=None):
 COLOR_UNPARK = (255, 165, 0, 255)  # orange
 COLOR_RASTER = (0, 120, 255, 255)  # blue
 COLOR_PARK = (255, 60, 60, 255)    # red
+COLOR_RECT = (180, 180, 180, 255)  # gray
 COLOR_LINE_CLK = (0, 200, 100, 255)
 COLOR_LINE_CLK_FLIM = (200, 100, 255, 255)
 COLOR_FRAME_CLK_FLIM = (255, 200, 50, 255)
@@ -323,6 +338,7 @@ def make_theme(color):
     return t
 
 
+
 def main():
     dpg.create_context()
     dpg.create_viewport(title="Waveform Viewer", width=1400, height=900)
@@ -330,6 +346,8 @@ def main():
     theme_unpark = make_theme(COLOR_UNPARK)
     theme_raster = make_theme(COLOR_RASTER)
     theme_park = make_theme(COLOR_PARK)
+    theme_rect = make_theme(COLOR_RECT)
+
     theme_line_clk = make_theme(COLOR_LINE_CLK)
     theme_line_clk_flim = make_theme(COLOR_LINE_CLK_FLIM)
     theme_frame_clk_flim = make_theme(COLOR_FRAME_CLK_FLIM)
@@ -460,6 +478,7 @@ def main():
                 with dpg.plot(label="X-Y Trajectory", height=-1, width=-1, equal_aspects=True):
                     dpg.add_plot_axis(dpg.mvXAxis, label="X (V)", tag="xy_ax_x")
                     with dpg.plot_axis(dpg.mvYAxis, label="Y (V)", tag="xy_ax_y"):
+                        dpg.add_line_series([], [], tag="xy_rect")
                         dpg.add_line_series([], [], tag="xy_unpark")
                         dpg.add_line_series([], [], tag="xy_raster")
                         dpg.add_line_series([], [], tag="xy_park")
@@ -471,6 +490,8 @@ def main():
     dpg.bind_item_theme("y_unpark", theme_unpark)
     dpg.bind_item_theme("y_raster", theme_raster)
     dpg.bind_item_theme("y_park", theme_park)
+
+    dpg.bind_item_theme("xy_rect", theme_rect)
     dpg.bind_item_theme("xy_unpark", theme_unpark)
     dpg.bind_item_theme("xy_raster", theme_raster)
     dpg.bind_item_theme("xy_park", theme_park)

--- a/WaveformTool/waveform_viewer.py
+++ b/WaveformTool/waveform_viewer.py
@@ -35,7 +35,12 @@ def find_waveform_tool() -> Path:
 TOOL_PATH = find_waveform_tool()
 
 
-def generate_waveform(
+def run_tool(args: list[str], tmp: Path) -> subprocess.CompletedProcess:
+    cmd = [str(TOOL_PATH)] + args + ["-o", str(tmp), "--format", "raw"]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def generate_raster(
     resolution: int,
     width: int,
     height: int,
@@ -49,39 +54,127 @@ def generate_waveform(
     with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as f:
         tmp = Path(f.name)
     try:
-        cmd = [
-            str(TOOL_PATH),
+        result = run_tool([
             "raster",
-            "-o",
-            str(tmp),
-            "--format",
-            "raw",
-            "--resolution",
-            str(resolution),
-            "--width",
-            str(width),
-            "--height",
-            str(height),
-            "--xoffset",
-            str(x_offset),
-            "--yoffset",
-            str(y_offset),
-            "--zoom",
-            str(zoom),
-            "--undershoot",
-            str(undershoot),
-            "--tform",
-            f"{tform[0]},{tform[1]},{tform[2]},{tform[3]}",
-            "--tform-offset",
-            f"{tform_offset[0]},{tform_offset[1]}",
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+            "--resolution", str(resolution),
+            "--width", str(width),
+            "--height", str(height),
+            "--xoffset", str(x_offset),
+            "--yoffset", str(y_offset),
+            "--zoom", str(zoom),
+            "--undershoot", str(undershoot),
+            "--tform", f"{tform[0]},{tform[1]},{tform[2]},{tform[3]}",
+            "--tform-offset", f"{tform_offset[0]},{tform_offset[1]}",
+        ], tmp)
         if result.returncode != 0:
-            return result.stderr.strip() or f"WaveformTool exited with code {result.returncode}"
+            return result.stderr.strip() or f"raster exited with code {result.returncode}"
         data = np.fromfile(tmp, dtype=np.float64)
         n = len(data) // 2
         if n == 0:
-            return "No data produced"
+            return "raster: no data produced"
+        return data[:n], data[n:]
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def generate_clock(
+    width: int,
+    height: int,
+    undershoot: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | str:
+    with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        result = run_tool([
+            "clock",
+            "--width", str(width),
+            "--height", str(height),
+            "--undershoot", str(undershoot),
+        ], tmp)
+        if result.returncode != 0:
+            return result.stderr.strip() or f"clock exited with code {result.returncode}"
+        data = np.fromfile(tmp, dtype=np.uint8)
+        n = len(data) // 3
+        if n == 0:
+            return "clock: no data produced"
+        return data[:n], data[n : 2 * n], data[2 * n :]
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def generate_park(
+    resolution: int,
+    zoom: float,
+    undershoot: int,
+    x_offset: int,
+    y_offset: int,
+    xpark: int,
+    ypark: int,
+    tform: tuple[float, float, float, float],
+    tform_offset: tuple[float, float],
+) -> tuple[np.ndarray, np.ndarray] | str:
+    with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        result = run_tool([
+            "park",
+            "--resolution", str(resolution),
+            "--zoom", str(zoom),
+            "--undershoot", str(undershoot),
+            "--xoffset", str(x_offset),
+            "--yoffset", str(y_offset),
+            "--xpark", str(xpark),
+            "--ypark", str(ypark),
+            "--tform", f"{tform[0]},{tform[1]},{tform[2]},{tform[3]}",
+            "--tform-offset", f"{tform_offset[0]},{tform_offset[1]}",
+        ], tmp)
+        if result.returncode != 0:
+            return result.stderr.strip() or f"park exited with code {result.returncode}"
+        data = np.fromfile(tmp, dtype=np.float64)
+        n = len(data) // 2
+        if n == 0:
+            return "park: no data produced"
+        return data[:n], data[n:]
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def generate_unpark(
+    resolution: int,
+    zoom: float,
+    undershoot: int,
+    x_offset: int,
+    y_offset: int,
+    xpark: int,
+    ypark: int,
+    prev_xpark_voltage: float,
+    prev_ypark_voltage: float,
+    tform: tuple[float, float, float, float],
+    tform_offset: tuple[float, float],
+) -> tuple[np.ndarray, np.ndarray] | str:
+    with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        result = run_tool([
+            "unpark",
+            "--resolution", str(resolution),
+            "--zoom", str(zoom),
+            "--undershoot", str(undershoot),
+            "--xoffset", str(x_offset),
+            "--yoffset", str(y_offset),
+            "--xpark", str(xpark),
+            "--ypark", str(ypark),
+            "--prev-xpark-voltage", str(prev_xpark_voltage),
+            "--prev-ypark-voltage", str(prev_ypark_voltage),
+            "--tform", f"{tform[0]},{tform[1]},{tform[2]},{tform[3]}",
+            "--tform-offset", f"{tform_offset[0]},{tform_offset[1]}",
+        ], tmp)
+        if result.returncode != 0:
+            return result.stderr.strip() or f"unpark exited with code {result.returncode}"
+        data = np.fromfile(tmp, dtype=np.float64)
+        n = len(data) // 2
+        if n == 0:
+            return "unpark: no data produced"
         return data[:n], data[n:]
     finally:
         tmp.unlink(missing_ok=True)
@@ -103,30 +196,108 @@ def on_generate(_sender=None, _data=None):
         dpg.get_value("tform_d"),
     )
     tform_offset = (dpg.get_value("tform_tx"), dpg.get_value("tform_ty"))
+    xpark = dpg.get_value("xpark")
+    ypark = dpg.get_value("ypark")
+    prev_xpv = dpg.get_value("prev_xpark_voltage")
+    prev_ypv = dpg.get_value("prev_ypark_voltage")
 
-    result = generate_waveform(
+    errors = []
+
+    unpark_result = generate_unpark(
+        resolution, zoom, undershoot, x_offset, y_offset,
+        xpark, ypark, prev_xpv, prev_ypv, tform, tform_offset,
+    )
+    if isinstance(unpark_result, str):
+        errors.append(unpark_result)
+
+    raster_result = generate_raster(
         resolution, width, height, x_offset, y_offset, zoom, undershoot,
         tform, tform_offset,
     )
+    if isinstance(raster_result, str):
+        errors.append(raster_result)
 
-    if isinstance(result, str):
-        dpg.set_value("status", f"Error: {result}")
-        return
+    park_result = generate_park(
+        resolution, zoom, undershoot, x_offset, y_offset,
+        xpark, ypark, tform, tform_offset,
+    )
+    if isinstance(park_result, str):
+        errors.append(park_result)
 
-    x, y = result
-    t = np.arange(len(x), dtype=np.float64)
-    dpg.set_value("status", f"Generated {len(x)} samples per channel")
+    clock_result = generate_clock(width, height, undershoot)
+    if isinstance(clock_result, str):
+        errors.append(clock_result)
 
-    dpg.set_value("x_series", [t.tolist(), x.tolist()])
-    dpg.set_value("y_series", [t.tolist(), y.tolist()])
-    dpg.set_value("xy_series", [x.tolist(), y.tolist()])
+    # Update X(t), Y(t), X-Y plots
+    have_unpark = not isinstance(unpark_result, str)
+    have_raster = not isinstance(raster_result, str)
+    have_park = not isinstance(park_result, str)
 
-    dpg.fit_axis_data("x_ax_x")
-    dpg.fit_axis_data("x_ax_y")
-    dpg.fit_axis_data("y_ax_x")
-    dpg.fit_axis_data("y_ax_y")
-    dpg.fit_axis_data("xy_ax_x")
-    dpg.fit_axis_data("xy_ax_y")
+    n_raster = len(raster_result[0]) if have_raster else 0
+
+    if have_unpark:
+        ux, uy = unpark_result
+        n_unpark = len(ux)
+        t_unpark = np.arange(-n_unpark, 0, dtype=np.float64)
+        dpg.set_value("x_unpark", [t_unpark.tolist(), ux.tolist()])
+        dpg.set_value("y_unpark", [t_unpark.tolist(), uy.tolist()])
+        dpg.set_value("xy_unpark", [ux.tolist(), uy.tolist()])
+    else:
+        dpg.set_value("x_unpark", [[], []])
+        dpg.set_value("y_unpark", [[], []])
+        dpg.set_value("xy_unpark", [[], []])
+
+    if have_raster:
+        rx, ry = raster_result
+        t_raster = np.arange(n_raster, dtype=np.float64)
+        dpg.set_value("x_raster", [t_raster.tolist(), rx.tolist()])
+        dpg.set_value("y_raster", [t_raster.tolist(), ry.tolist()])
+        dpg.set_value("xy_raster", [rx.tolist(), ry.tolist()])
+    else:
+        dpg.set_value("x_raster", [[], []])
+        dpg.set_value("y_raster", [[], []])
+        dpg.set_value("xy_raster", [[], []])
+
+    if have_park:
+        px, py = park_result
+        n_park = len(px)
+        t_park = np.arange(n_raster, n_raster + n_park, dtype=np.float64)
+        dpg.set_value("x_park", [t_park.tolist(), px.tolist()])
+        dpg.set_value("y_park", [t_park.tolist(), py.tolist()])
+        dpg.set_value("xy_park", [px.tolist(), py.tolist()])
+    else:
+        dpg.set_value("x_park", [[], []])
+        dpg.set_value("y_park", [[], []])
+        dpg.set_value("xy_park", [[], []])
+
+    # Update clock plot
+    if not isinstance(clock_result, str):
+        line_clk, line_clk_flim, frame_clk_flim = clock_result
+        n_clk = len(line_clk)
+        t_clk = np.arange(n_clk, dtype=np.float64)
+        dpg.set_value("clk_line", [t_clk.tolist(), line_clk.astype(np.float64).tolist()])
+        dpg.set_value("clk_line_flim", [t_clk.tolist(), line_clk_flim.astype(np.float64).tolist()])
+        dpg.set_value("clk_frame_flim", [t_clk.tolist(), frame_clk_flim.astype(np.float64).tolist()])
+    else:
+        dpg.set_value("clk_line", [[], []])
+        dpg.set_value("clk_line_flim", [[], []])
+        dpg.set_value("clk_frame_flim", [[], []])
+
+    for ax in ("x_ax_x", "x_ax_y", "y_ax_x", "y_ax_y",
+               "xy_ax_x", "xy_ax_y", "clk_ax_x", "clk_ax_y"):
+        dpg.fit_axis_data(ax)
+
+    if errors:
+        dpg.set_value("status", "Errors: " + "; ".join(errors))
+    else:
+        parts = []
+        if have_unpark:
+            parts.append(f"unpark={len(unpark_result[0])}")
+        if have_raster:
+            parts.append(f"raster={n_raster}")
+        if have_park:
+            parts.append(f"park={len(park_result[0])}")
+        dpg.set_value("status", f"Samples/ch: {', '.join(parts)}")
 
 
 def on_size_toggle(_sender=None, _data=None):
@@ -136,9 +307,32 @@ def on_size_toggle(_sender=None, _data=None):
     on_generate()
 
 
+# Theme colors
+COLOR_UNPARK = (255, 165, 0, 255)  # orange
+COLOR_RASTER = (0, 120, 255, 255)  # blue
+COLOR_PARK = (255, 60, 60, 255)    # red
+COLOR_LINE_CLK = (0, 200, 100, 255)
+COLOR_LINE_CLK_FLIM = (200, 100, 255, 255)
+COLOR_FRAME_CLK_FLIM = (255, 200, 50, 255)
+
+
+def make_theme(color):
+    with dpg.theme() as t:
+        with dpg.theme_component(dpg.mvLineSeries):
+            dpg.add_theme_color(dpg.mvPlotCol_Line, color, category=dpg.mvThemeCat_Plots)
+    return t
+
+
 def main():
     dpg.create_context()
-    dpg.create_viewport(title="Waveform Viewer", width=1400, height=800)
+    dpg.create_viewport(title="Waveform Viewer", width=1400, height=900)
+
+    theme_unpark = make_theme(COLOR_UNPARK)
+    theme_raster = make_theme(COLOR_RASTER)
+    theme_park = make_theme(COLOR_PARK)
+    theme_line_clk = make_theme(COLOR_LINE_CLK)
+    theme_line_clk_flim = make_theme(COLOR_LINE_CLK_FLIM)
+    theme_frame_clk_flim = make_theme(COLOR_FRAME_CLK_FLIM)
 
     with dpg.window(tag="main_window"):
         with dpg.group(horizontal=True):
@@ -188,6 +382,26 @@ def main():
                 )
 
                 dpg.add_separator()
+                dpg.add_text("Park / Unpark")
+
+                dpg.add_input_int(
+                    label="X Park", tag="xpark",
+                    default_value=0, callback=on_generate,
+                )
+                dpg.add_input_int(
+                    label="Y Park", tag="ypark",
+                    default_value=0, callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="Prev X Park (V)", tag="prev_xpark_voltage",
+                    default_value=0.0, format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="Prev Y Park (V)", tag="prev_ypark_voltage",
+                    default_value=0.0, format="%.6f", callback=on_generate,
+                )
+
+                dpg.add_separator()
                 dpg.add_text("Affine Transform")
 
                 dpg.add_input_float(
@@ -221,20 +435,48 @@ def main():
 
             # Right panel: plots
             with dpg.group():
-                with dpg.plot(label="X(t)", height=230, width=-1):
+                with dpg.plot(label="Clock Signals", height=150, width=-1):
+                    dpg.add_plot_axis(dpg.mvXAxis, label="Sample", tag="clk_ax_x")
+                    with dpg.plot_axis(dpg.mvYAxis, label="Value", tag="clk_ax_y"):
+                        dpg.add_line_series([], [], label="lineClock", tag="clk_line")
+                        dpg.add_line_series([], [], label="lineClockFLIM", tag="clk_line_flim")
+                        dpg.add_line_series([], [], label="frameClockFLIM", tag="clk_frame_flim")
+                    dpg.add_plot_legend()
+
+                with dpg.plot(label="X(t)", height=200, width=-1):
                     dpg.add_plot_axis(dpg.mvXAxis, label="Sample", tag="x_ax_x")
                     with dpg.plot_axis(dpg.mvYAxis, label="X (V)", tag="x_ax_y"):
-                        dpg.add_line_series([], [], tag="x_series")
+                        dpg.add_line_series([], [], tag="x_unpark")
+                        dpg.add_line_series([], [], tag="x_raster")
+                        dpg.add_line_series([], [], tag="x_park")
 
-                with dpg.plot(label="Y(t)", height=230, width=-1):
+                with dpg.plot(label="Y(t)", height=200, width=-1):
                     dpg.add_plot_axis(dpg.mvXAxis, label="Sample", tag="y_ax_x")
                     with dpg.plot_axis(dpg.mvYAxis, label="Y (V)", tag="y_ax_y"):
-                        dpg.add_line_series([], [], tag="y_series")
+                        dpg.add_line_series([], [], tag="y_unpark")
+                        dpg.add_line_series([], [], tag="y_raster")
+                        dpg.add_line_series([], [], tag="y_park")
 
                 with dpg.plot(label="X-Y Trajectory", height=-1, width=-1, equal_aspects=True):
                     dpg.add_plot_axis(dpg.mvXAxis, label="X (V)", tag="xy_ax_x")
                     with dpg.plot_axis(dpg.mvYAxis, label="Y (V)", tag="xy_ax_y"):
-                        dpg.add_line_series([], [], tag="xy_series")
+                        dpg.add_line_series([], [], tag="xy_unpark")
+                        dpg.add_line_series([], [], tag="xy_raster")
+                        dpg.add_line_series([], [], tag="xy_park")
+
+    # Apply themes
+    dpg.bind_item_theme("x_unpark", theme_unpark)
+    dpg.bind_item_theme("x_raster", theme_raster)
+    dpg.bind_item_theme("x_park", theme_park)
+    dpg.bind_item_theme("y_unpark", theme_unpark)
+    dpg.bind_item_theme("y_raster", theme_raster)
+    dpg.bind_item_theme("y_park", theme_park)
+    dpg.bind_item_theme("xy_unpark", theme_unpark)
+    dpg.bind_item_theme("xy_raster", theme_raster)
+    dpg.bind_item_theme("xy_park", theme_park)
+    dpg.bind_item_theme("clk_line", theme_line_clk)
+    dpg.bind_item_theme("clk_line_flim", theme_line_clk_flim)
+    dpg.bind_item_theme("clk_frame_flim", theme_frame_clk_flim)
 
     dpg.set_primary_window("main_window", True)
     dpg.setup_dearpygui()

--- a/WaveformTool/waveform_viewer.py
+++ b/WaveformTool/waveform_viewer.py
@@ -1,0 +1,250 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "dearpygui",
+#     "numpy",
+# ]
+# ///
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import dearpygui.dearpygui as dpg
+import numpy as np
+
+
+def find_waveform_tool() -> Path:
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        script_dir / "WaveformTool.exe",
+        script_dir / "WaveformTool",
+        script_dir.parent / "builddir" / "WaveformTool" / "WaveformTool.exe",
+        script_dir.parent / "builddir" / "WaveformTool" / "WaveformTool",
+    ]
+    for p in candidates:
+        if p.is_file():
+            return p
+    sys.exit(
+        "Cannot find WaveformTool executable. Searched:\n"
+        + "\n".join(f"  {c}" for c in candidates)
+    )
+
+
+TOOL_PATH = find_waveform_tool()
+
+
+def generate_waveform(
+    resolution: int,
+    width: int,
+    height: int,
+    x_offset: int,
+    y_offset: int,
+    zoom: float,
+    undershoot: int,
+    tform: tuple[float, float, float, float],
+    tform_offset: tuple[float, float],
+) -> tuple[np.ndarray, np.ndarray] | str:
+    with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        cmd = [
+            str(TOOL_PATH),
+            "raster",
+            "-o",
+            str(tmp),
+            "--format",
+            "raw",
+            "--resolution",
+            str(resolution),
+            "--width",
+            str(width),
+            "--height",
+            str(height),
+            "--xoffset",
+            str(x_offset),
+            "--yoffset",
+            str(y_offset),
+            "--zoom",
+            str(zoom),
+            "--undershoot",
+            str(undershoot),
+            "--tform",
+            f"{tform[0]},{tform[1]},{tform[2]},{tform[3]}",
+            "--tform-offset",
+            f"{tform_offset[0]},{tform_offset[1]}",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            return result.stderr.strip() or f"WaveformTool exited with code {result.returncode}"
+        data = np.fromfile(tmp, dtype=np.float64)
+        n = len(data) // 2
+        if n == 0:
+            return "No data produced"
+        return data[:n], data[n:]
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def on_generate(_sender=None, _data=None):
+    resolution = dpg.get_value("resolution")
+    use_res = dpg.get_value("size_equals_res")
+    width = resolution if use_res else dpg.get_value("width")
+    height = resolution if use_res else dpg.get_value("height")
+    x_offset = dpg.get_value("x_offset")
+    y_offset = dpg.get_value("y_offset")
+    zoom = dpg.get_value("zoom")
+    undershoot = dpg.get_value("undershoot")
+    tform = (
+        dpg.get_value("tform_a"),
+        dpg.get_value("tform_b"),
+        dpg.get_value("tform_c"),
+        dpg.get_value("tform_d"),
+    )
+    tform_offset = (dpg.get_value("tform_tx"), dpg.get_value("tform_ty"))
+
+    result = generate_waveform(
+        resolution, width, height, x_offset, y_offset, zoom, undershoot,
+        tform, tform_offset,
+    )
+
+    if isinstance(result, str):
+        dpg.set_value("status", f"Error: {result}")
+        return
+
+    x, y = result
+    t = np.arange(len(x), dtype=np.float64)
+    dpg.set_value("status", f"Generated {len(x)} samples per channel")
+
+    dpg.set_value("x_series", [t.tolist(), x.tolist()])
+    dpg.set_value("y_series", [t.tolist(), y.tolist()])
+    dpg.set_value("xy_series", [x.tolist(), y.tolist()])
+
+    dpg.fit_axis_data("x_ax_x")
+    dpg.fit_axis_data("x_ax_y")
+    dpg.fit_axis_data("y_ax_x")
+    dpg.fit_axis_data("y_ax_y")
+    dpg.fit_axis_data("xy_ax_x")
+    dpg.fit_axis_data("xy_ax_y")
+
+
+def on_size_toggle(_sender=None, _data=None):
+    linked = dpg.get_value("size_equals_res")
+    dpg.configure_item("width", enabled=not linked)
+    dpg.configure_item("height", enabled=not linked)
+    on_generate()
+
+
+def main():
+    dpg.create_context()
+    dpg.create_viewport(title="Waveform Viewer", width=1400, height=800)
+
+    with dpg.window(tag="main_window"):
+        with dpg.group(horizontal=True):
+            # Left panel: controls
+            with dpg.child_window(width=300):
+                dpg.add_text("Scan Parameters")
+                dpg.add_separator()
+
+                dpg.add_input_int(
+                    label="Resolution", tag="resolution",
+                    default_value=256, min_value=1, min_clamped=True,
+                    callback=on_generate,
+                )
+                dpg.add_checkbox(
+                    label="Width/Height = Resolution", tag="size_equals_res",
+                    default_value=True, callback=on_size_toggle,
+                )
+                dpg.add_input_int(
+                    label="Width", tag="width",
+                    default_value=256, min_value=1, min_clamped=True,
+                    enabled=False, callback=on_generate,
+                )
+                dpg.add_input_int(
+                    label="Height", tag="height",
+                    default_value=256, min_value=1, min_clamped=True,
+                    enabled=False, callback=on_generate,
+                )
+                dpg.add_input_int(
+                    label="X Offset", tag="x_offset",
+                    default_value=0, min_value=0, min_clamped=True,
+                    callback=on_generate,
+                )
+                dpg.add_input_int(
+                    label="Y Offset", tag="y_offset",
+                    default_value=0, min_value=0, min_clamped=True,
+                    callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="Zoom", tag="zoom",
+                    default_value=1.0, min_value=0.01, min_clamped=True,
+                    format="%.3f", callback=on_generate,
+                )
+                dpg.add_input_int(
+                    label="Undershoot", tag="undershoot",
+                    default_value=0, min_value=0, min_clamped=True,
+                    callback=on_generate,
+                )
+
+                dpg.add_separator()
+                dpg.add_text("Affine Transform")
+
+                dpg.add_input_float(
+                    label="a", tag="tform_a", default_value=1.0,
+                    format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="b", tag="tform_b", default_value=0.0,
+                    format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="c", tag="tform_c", default_value=0.0,
+                    format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="d", tag="tform_d", default_value=1.0,
+                    format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="tx (V)", tag="tform_tx", default_value=0.0,
+                    format="%.6f", callback=on_generate,
+                )
+                dpg.add_input_float(
+                    label="ty (V)", tag="tform_ty", default_value=0.0,
+                    format="%.6f", callback=on_generate,
+                )
+
+                dpg.add_separator()
+                dpg.add_button(label="Generate", callback=on_generate, width=-1)
+                dpg.add_text("", tag="status")
+
+            # Right panel: plots
+            with dpg.group():
+                with dpg.plot(label="X(t)", height=230, width=-1):
+                    dpg.add_plot_axis(dpg.mvXAxis, label="Sample", tag="x_ax_x")
+                    with dpg.plot_axis(dpg.mvYAxis, label="X (V)", tag="x_ax_y"):
+                        dpg.add_line_series([], [], tag="x_series")
+
+                with dpg.plot(label="Y(t)", height=230, width=-1):
+                    dpg.add_plot_axis(dpg.mvXAxis, label="Sample", tag="y_ax_x")
+                    with dpg.plot_axis(dpg.mvYAxis, label="Y (V)", tag="y_ax_y"):
+                        dpg.add_line_series([], [], tag="y_series")
+
+                with dpg.plot(label="X-Y Trajectory", height=-1, width=-1, equal_aspects=True):
+                    dpg.add_plot_axis(dpg.mvXAxis, label="X (V)", tag="xy_ax_x")
+                    with dpg.plot_axis(dpg.mvYAxis, label="Y (V)", tag="xy_ax_y"):
+                        dpg.add_line_series([], [], tag="xy_series")
+
+    dpg.set_primary_window("main_window", True)
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+
+    on_generate()
+
+    dpg.start_dearpygui()
+    dpg.destroy_context()
+
+
+if __name__ == "__main__":
+    main()

--- a/meson.build
+++ b/meson.build
@@ -71,3 +71,4 @@ shared_module(
 )
 
 subdir('DumpWaveform')
+subdir('WaveformTool')

--- a/src/DAQConfig.c
+++ b/src/DAQConfig.c
@@ -59,8 +59,10 @@ void SetWaveformParamsFromDevice(OScDev_Device *device,
     OScDev_Acquisition_GetROI(acq, &parameters->xOffset, &parameters->yOffset,
                               &parameters->width, &parameters->height);
     parameters->undershoot = GetImplData(device)->lineDelay;
-    parameters->galvoOffsetX = GetImplData(device)->offsetXY[0];
-    parameters->galvoOffsetY = GetImplData(device)->offsetXY[1];
+    for (int i = 0; i < 4; ++i)
+        parameters->xformMatrix[i] = GetImplData(device)->xformMatrix[i];
+    parameters->xformOffsetX = GetImplData(device)->xformOffsetX;
+    parameters->xformOffsetY = GetImplData(device)->xformOffsetY;
     parameters->xPark = GetImplData(device)->xPark;
     parameters->yPark = GetImplData(device)->yPark;
     parameters->prevXParkVoltage = GetImplData(device)->prevXParkVoltage;

--- a/src/DeviceImplData.c
+++ b/src/DeviceImplData.c
@@ -11,6 +11,12 @@ void InitializeImplData(struct DeviceImplData *data) {
 
     ss8_init(&data->deviceName);
     data->lineDelay = 50;
+    data->xformMatrix[0] = 1.0;
+    data->xformMatrix[1] = 0.0;
+    data->xformMatrix[2] = 0.0;
+    data->xformMatrix[3] = 1.0;
+    data->xformOffsetX = 0.0;
+    data->xformOffsetY = 0.0;
     data->numLinesToBuffer = 8;
     data->inputVoltageRange = 10.0;
     data->minVolts_ = -10.0;

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -44,9 +44,11 @@ struct DeviceImplData {
     double inputVoltageRange;
     uInt32
         numDOChannels; // Number of DO lines under current clock configuration
-    double offsetXY[2];
-    double minVolts_; // min possible for device
-    double maxVolts_; // max possible for device
+    double xformMatrix[4]; // {a, b, c, d} — row-major 2x2
+    double xformOffsetX;   // tx (volts)
+    double xformOffsetY;   // ty (volts)
+    double minVolts_;      // min possible for device
+    double maxVolts_;      // max possible for device
 
     int numAIPhysChans; // Not to exceed MAX_PHYSICAL_CHANS
     ss8str aiPhysChans; // at least numAIPhysChans elements separated by ", "

--- a/src/OpenScanSettings.c
+++ b/src/OpenScanSettings.c
@@ -206,51 +206,60 @@ static OScDev_SettingImpl SettingImpl_EnableChannel = {
     .SetBool = SetEnableChannel,
 };
 
-struct OffsetSettingData {
+struct TransformSettingData {
     OScDev_Device *device;
-    int axis; // 0 = x, 1 = y
+    int index; // 0-3 = matrix[0-3], 4 = offsetX, 5 = offsetY
 };
 
-static OScDev_Error GetOffset(OScDev_Setting *setting, double *value) {
-    struct OffsetSettingData *data =
-        (struct OffsetSettingData *)OScDev_Setting_GetImplData(setting);
-    *value = GetImplData(data->device)->offsetXY[data->axis];
+static double *GetTransformField(struct DeviceImplData *devData, int index) {
+    if (index < 4)
+        return &devData->xformMatrix[index];
+    if (index == 4)
+        return &devData->xformOffsetX;
+    return &devData->xformOffsetY;
+}
+
+static OScDev_Error GetTransform(OScDev_Setting *setting, double *value) {
+    struct TransformSettingData *data = OScDev_Setting_GetImplData(setting);
+    *value = *GetTransformField(GetImplData(data->device), data->index);
     return OScDev_OK;
 }
 
-static OScDev_Error SetOffset(OScDev_Setting *setting, double value) {
-    struct OffsetSettingData *data =
-        (struct OffsetSettingData *)OScDev_Setting_GetImplData(setting);
-    GetImplData(data->device)->offsetXY[data->axis] = value;
+static OScDev_Error SetTransform(OScDev_Setting *setting, double value) {
+    struct TransformSettingData *data = OScDev_Setting_GetImplData(setting);
+    *GetTransformField(GetImplData(data->device), data->index) = value;
 
-    GetImplData(data->device)->clockConfig.mustRewriteOutput = true;
     GetImplData(data->device)->scannerConfig.mustRewriteOutput = true;
 
     return OScDev_OK;
 }
 
-static OScDev_Error GetOffsetRange(OScDev_Setting *setting, double *min,
-                                   double *max) {
-    (void)setting; // Unused
-    /*The galvoOffsetX and galvoOffsetY variables are expressed  in optical
-    degrees This is a rough correspondence - it likely needs to be calibrated
-    to the actual sensitivity of the galvos*/
-    *min = -5.0;
-    *max = +5.0;
+static OScDev_Error GetTransformRange(OScDev_Setting *setting, double *min,
+                                      double *max) {
+    struct TransformSettingData *data = OScDev_Setting_GetImplData(setting);
+    if (data->index == 0 || data->index == 3) {
+        *min = 0.9;
+        *max = 1.1;
+    } else if (data->index < 4) {
+        *min = -0.1;
+        *max = 0.1;
+    } else {
+        *min = -5.0;
+        *max = 5.0;
+    }
     return OScDev_OK;
 }
 
-static void ReleaseOffset(OScDev_Setting *setting) {
-    struct OffsetSettingData *data = OScDev_Setting_GetImplData(setting);
-    free(data);
+static void ReleaseTransform(OScDev_Setting *setting) {
+    free(OScDev_Setting_GetImplData(setting));
 }
 
-static OScDev_SettingImpl SettingImpl_Offset = {
-    .GetFloat64 = GetOffset,
-    .SetFloat64 = SetOffset,
+static OScDev_SettingImpl SettingImpl_Transform = {
+    .GetFloat64 = GetTransform,
+    .SetFloat64 = SetTransform,
     .GetNumericConstraintType = GetNumericConstraintTypeImpl_Range,
-    .GetFloat64Range = GetOffsetRange,
-    .Release = ReleaseOffset,
+    .GetFloat64Range = GetTransformRange,
+    .Release = ReleaseTransform,
 };
 
 OScDev_Error NIDAQMakeSettings(OScDev_Device *device,
@@ -287,20 +296,28 @@ OScDev_Error NIDAQMakeSettings(OScDev_Device *device,
         goto error;
     OScDev_PtrArray_Append(*settings, parkingPositionY);
 
-    for (int i = 0; i < 2; ++i) {
-        OScDev_Setting *offset;
-        struct OffsetSettingData *data =
-            malloc(sizeof(struct OffsetSettingData));
-        data->device = device;
-        data->axis = i;
-        const char *name =
-            i == 0 ? "GalvoOffsetX (degree)" : "GalvoOffsetY (degree)";
-        err = OScDev_Error_AsRichError(
-            OScDev_Setting_Create(&offset, name, OScDev_ValueType_Float64,
-                                  &SettingImpl_Offset, data));
-        if (err)
-            goto error;
-        OScDev_PtrArray_Append(*settings, offset);
+    {
+        static const char *transformNames[] = {
+            "TransformA",
+            "TransformB",
+            "TransformC",
+            "TransformD",
+            "TransformOffsetXVolts",
+            "TransformOffsetYVolts",
+        };
+        for (int i = 0; i < 6; ++i) {
+            OScDev_Setting *xformSetting;
+            struct TransformSettingData *data =
+                malloc(sizeof(struct TransformSettingData));
+            data->device = device;
+            data->index = i;
+            err = OScDev_Error_AsRichError(OScDev_Setting_Create(
+                &xformSetting, transformNames[i], OScDev_ValueType_Float64,
+                &SettingImpl_Transform, data));
+            if (err)
+                goto error;
+            OScDev_PtrArray_Append(*settings, xformSetting);
+        }
     }
 
     OScDev_Setting *numLinesToBuffer;

--- a/src/Waveform.c
+++ b/src/Waveform.c
@@ -73,9 +73,18 @@ static void GenerateYGalvoWaveform(int32_t linesPerFrame, int32_t retraceLen,
         }
     }
 
+    // Smooth Y transitions during each line's X retrace
+    for (int j = 0; j < linesPerFrame - 1; ++j) {
+        double yThis = scanStart + step * j;
+        double yNext = scanStart + step * (j + 1);
+        SplineInterpolate(X_RETRACE_LEN, yThis, yNext, 0, 0,
+                          waveform + (j + 1) * xLength - X_RETRACE_LEN);
+    }
+
     // Generate the rescan curve at end of frame
     if (X_RETRACE_LEN > 0) {
-        SplineInterpolate(X_RETRACE_LEN, scanEnd, scanStart, 0, 0,
+        double lastLineY = scanStart + step * (linesPerFrame - 1);
+        SplineInterpolate(X_RETRACE_LEN, lastLineY, scanStart, 0, 0,
                           waveform + (linesPerFrame * xLength) -
                               X_RETRACE_LEN);
     }

--- a/src/Waveform.c
+++ b/src/Waveform.c
@@ -171,8 +171,9 @@ void GenerateGalvoWaveformFrame(const struct WaveformParams *parameters,
     uint32_t undershoot = parameters->undershoot;
     uint32_t xOffset = parameters->xOffset; // ROI offset
     uint32_t yOffset = parameters->yOffset;
-    double galvoOffsetX = parameters->galvoOffsetX; // Adjustment Offset
-    double galvoOffsetY = parameters->galvoOffsetY;
+    const double *m = parameters->xformMatrix;
+    double tx = parameters->xformOffsetX;
+    double ty = parameters->xformOffsetY;
 
     // Voltage ranges of the ROI
     double xStart = (-0.5 * resolution + xOffset) / (zoom * resolution);
@@ -184,33 +185,19 @@ void GenerateGalvoWaveformFrame(const struct WaveformParams *parameters,
     size_t yLength = linesPerFrame;
 
     double *xWaveform = (double *)malloc(sizeof(double) * xLength);
-    double *yWaveform =
-        (double *)malloc(sizeof(double) * (yLength * xLength)); // change size
+    double *yWaveform = (double *)malloc(sizeof(double) * (yLength * xLength));
     GenerateXGalvoWaveform(pixelsPerLine, X_RETRACE_LEN, undershoot, xStart,
                            xEnd, xWaveform);
     GenerateYGalvoWaveform(linesPerFrame, X_RETRACE_LEN, xLength, yStart, yEnd,
                            yWaveform);
 
-    // convert to optical degree assuming 10V equal to 30 optical degree
-    // TODO We shouldn't make such an assumption! Also I think the variable
-    // names are the other way around ("inDegree" means "in volts" here).
-    double offsetXinDegree = galvoOffsetX / 3.0;
-    double offsetYinDegree = galvoOffsetY / 3.0;
-
-    // effective scan waveform for a whole frame
     for (unsigned j = 0; j < yLength; ++j) {
         for (unsigned i = 0; i < xLength; ++i) {
-            // first half is X waveform,
-            // x line scan repeated yLength times (sawteeth)
-            // galvo x stays at starting position after one frame is scanned
-            xyWaveformFrame[i + j * xLength] = xWaveform[i] + offsetXinDegree;
-
-            // xyWaveformFrame[i + j*xLength] = xWaveform[i];
-            //  second half is Y waveform
-            //  at each x (fast) scan line, y value is constant
-            //  effectively y retrace takes (Y_RETRACE_LENGTH * xLength) steps
+            double x = xWaveform[i];
+            double y = yWaveform[i + j * xLength];
+            xyWaveformFrame[i + j * xLength] = m[0] * x + m[1] * y + tx;
             xyWaveformFrame[i + j * xLength + yLength * xLength] =
-                yWaveform[i + j * xLength] + offsetYinDegree;
+                m[2] * x + m[3] * y + ty;
         }
     }
 
@@ -224,25 +211,31 @@ void GenerateGalvoWaveformFrame(const struct WaveformParams *parameters,
 }
 
 // Generate waveform from parking to start before one frame
+static void InverseTransform2x2(const double *m, double tx, double ty,
+                                double ox, double oy, double *lx, double *ly) {
+    double det = m[0] * m[3] - m[1] * m[2];
+    double cx = ox - tx;
+    double cy = oy - ty;
+    *lx = (m[3] * cx - m[1] * cy) / det;
+    *ly = (-m[2] * cx + m[0] * cy) / det;
+}
+
 void GenerateGalvoUnparkWaveform(const struct WaveformParams *parameters,
                                  double *xyWaveformFrame) {
     uint32_t resolution = parameters->resolution;
     double zoom = parameters->zoom;
-    uint32_t xOffset = parameters->xOffset; // ROI offset
+    uint32_t xOffset = parameters->xOffset;
     uint32_t yOffset = parameters->yOffset;
-    double galvoOffsetX = parameters->galvoOffsetX; // Adjustment Offset
-    double galvoOffsetY = parameters->galvoOffsetY;
     int32_t undershoot = parameters->undershoot;
-    double xParkVoltage = parameters->prevXParkVoltage;
-    double yParkVoltage = parameters->prevYParkVoltage;
+    const double *m = parameters->xformMatrix;
+    double tx = parameters->xformOffsetX;
+    double ty = parameters->xformOffsetY;
 
-    double offsetXinDegree = galvoOffsetX / 3.0;
-    double offsetYinDegree = galvoOffsetY / 3.0;
+    // Inverse-transform previous park voltage to logical space
+    double xStart, yStart;
+    InverseTransform2x2(m, tx, ty, parameters->prevXParkVoltage,
+                        parameters->prevYParkVoltage, &xStart, &yStart);
 
-    // Voltage ranges of the ROI
-    // Remove offset from start (it was baked in from previous park)
-    double xStart = xParkVoltage - offsetXinDegree;
-    double yStart = yParkVoltage - offsetYinDegree;
     double xEnd =
         (-0.5 * resolution + xOffset - undershoot) / (zoom * resolution);
     double yEnd = (-0.5 * resolution + yOffset) / (zoom * resolution);
@@ -254,14 +247,11 @@ void GenerateGalvoUnparkWaveform(const struct WaveformParams *parameters,
     SplineInterpolate((int32_t)length, xStart, xEnd, 0, 0, xWaveform);
     SplineInterpolate((int32_t)length, yStart, yEnd, 0, 0, yWaveform);
 
-    // effective scan waveform for a whole frame
     for (unsigned i = 0; i < length; ++i) {
-        // first half is X waveform,
-        // x line scan repeated yLength times (sawteeth)
-        xyWaveformFrame[i] = xWaveform[i] + offsetXinDegree;
-
-        // second half is Y waveform
-        xyWaveformFrame[i + length] = yWaveform[i] + offsetYinDegree;
+        double x = xWaveform[i];
+        double y = yWaveform[i];
+        xyWaveformFrame[i] = m[0] * x + m[1] * y + tx;
+        xyWaveformFrame[i + length] = m[2] * x + m[3] * y + ty;
     }
 
     free(xWaveform);
@@ -273,15 +263,15 @@ void GenerateGalvoParkWaveform(const struct WaveformParams *parameters,
                                double *xyWaveformFrame) {
     uint32_t resolution = parameters->resolution;
     double zoom = parameters->zoom;
-    uint32_t xOffset = parameters->xOffset; // ROI offset
+    uint32_t xOffset = parameters->xOffset;
     uint32_t yOffset = parameters->yOffset;
-    double galvoOffsetX = parameters->galvoOffsetX; // Adjustment Offset
-    double galvoOffsetY = parameters->galvoOffsetY;
     int32_t undershoot = parameters->undershoot;
     int32_t xPark = parameters->xPark;
     int32_t yPark = parameters->yPark;
+    const double *m = parameters->xformMatrix;
+    double tx = parameters->xformOffsetX;
+    double ty = parameters->xformOffsetY;
 
-    // Voltage ranges of the ROI
     double xStart =
         (-0.5 * resolution + xOffset - undershoot) / (zoom * resolution);
     double yStart = (-0.5 * resolution + yOffset) / (zoom * resolution);
@@ -295,19 +285,11 @@ void GenerateGalvoParkWaveform(const struct WaveformParams *parameters,
     SplineInterpolate((int32_t)length, xStart, xEnd, 0, 0, xWaveform);
     SplineInterpolate((int32_t)length, yStart, yEnd, 0, 0, yWaveform);
 
-    double offsetXinDegree = galvoOffsetX / 3.0;
-    double offsetYinDegree = galvoOffsetY / 3.0;
-
-    // effective scan waveform for a whole frame
     for (unsigned i = 0; i < length; ++i) {
-        // first half is X waveform,
-        // x line scan repeated yLength times (sawteeth)
-        // galvo x stays at starting position after one frame is scanned
-        xyWaveformFrame[i] = xWaveform[i] + offsetXinDegree;
-
-        // xyWaveformFrame[i + j*xLength] = xWaveform[i];
-        //  second half is Y waveform
-        xyWaveformFrame[i + length] = yWaveform[i] + offsetYinDegree;
+        double x = xWaveform[i];
+        double y = yWaveform[i];
+        xyWaveformFrame[i] = m[0] * x + m[1] * y + tx;
+        xyWaveformFrame[i + length] = m[2] * x + m[3] * y + ty;
     }
 
     free(xWaveform);

--- a/src/Waveform.h
+++ b/src/Waveform.h
@@ -10,8 +10,9 @@ struct WaveformParams {
     uint32_t undershoot; // also LineDelay for clock waveforms
     uint32_t xOffset;
     uint32_t yOffset;
-    double galvoOffsetX;
-    double galvoOffsetY;
+    double xformMatrix[4]; // {a, b, c, d} — row-major 2x2
+    double xformOffsetX;   // tx (volts)
+    double xformOffsetY;   // ty (volts)
     int32_t xPark;
     int32_t yPark;
     double prevXParkVoltage;


### PR DESCRIPTION
Allow to correct the scan waveform for small rotation, shear, and unequal X/Y scaling.

This replaces the `GalvoOffsetX (degree)` and `GalvoOffsetY (degree)` settings (both assumed 3 degrees/V) with:
- `TransformA`, `TransformB`, `TransformC`, `TransformD` for the linear part
- `TransformOffsetXVolts`, `TransformOffsetYVolts` for the translation part

The affine transformation is applied to the waveform _after_ zoom, resolution, ROI are handled.

If nonzero GalvoOffset was previously used, the values should be divided by 3 and entered for the TransformOffset.

The linear part (A/B/C/D) is restricted to +/-0.1 deviation from the identity matrix to prevent extreme changes that we might not handle well.

Also add WaveformTool (a more complete replacement for DumpWaveform) and waveform_viewer.py.