### PR TITLE
Continuous scan

### DIFF
--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -177,7 +177,11 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
                                               2 * estFrameTimeMs)) {
                     break; // timeout
                 }
-                if (GetImplData(device)->acquisition.stopRequested)
+                bool stopReq;
+                EnterCriticalSection(&GetImplData(device)->acquisition.mutex);
+                stopReq = GetImplData(device)->acquisition.stopRequested;
+                LeaveCriticalSection(&GetImplData(device)->acquisition.mutex);
+                if (stopReq)
                     break;
             }
 
@@ -190,7 +194,10 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
 
             if (!gotFrame) {
-                if (!GetImplData(device)->acquisition.stopRequested)
+                EnterCriticalSection(&GetImplData(device)->acquisition.mutex);
+                stopRequested = GetImplData(device)->acquisition.stopRequested;
+                LeaveCriticalSection(&GetImplData(device)->acquisition.mutex);
+                if (!stopRequested)
                     OScDev_Log_Error(device, "Error: Acquisition timeout!");
                 break;
             }

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -120,18 +120,50 @@ static OScDev_RichError *StopScan(OScDev_Device *device) {
     return lastErr;
 }
 
+static void LogRichError(OScDev_Device *device, OScDev_RichError *err) {
+    char msg[OScDev_MAX_STR_LEN + 1];
+    OScDev_Error_FormatRecursive(err, msg, sizeof(msg));
+    OScDev_Log_Error(device, msg);
+}
+
 static DWORD WINAPI AcquisitionLoop(void *param) {
     OScDev_Device *device = (OScDev_Device *)param;
     OScDev_Acquisition *acq = GetImplData(device)->acquisition.acquisition;
 
     uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
+    OScDev_RichError *err;
 
-    CreateScannerTask(device, &GetImplData(device)->scannerConfig);
-    ConfigureUnparkTiming(device, &GetImplData(device)->scannerConfig, acq);
-    WriteUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
-    GenerateUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    err = CreateScannerTask(device, &GetImplData(device)->scannerConfig);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
 
-    SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
+    err = ConfigureUnparkTiming(device, &GetImplData(device)->scannerConfig,
+                                acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
+
+    err = WriteUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
+
+    err =
+        GenerateUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
+
+    err = SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
 
     GetImplData(device)->readBufferState = READ_BUFFER_IDLE;
     GetImplData(device)->framePixelsFilled = 0;
@@ -145,13 +177,12 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
     uint32_t estFrameTimeMs =
         (uint32_t)(1e3 * totalElementsPerFramePerChan / pixelRateHz);
 
-    OScDev_RichError *err;
     err = StartScan(device);
     if (err) {
-        char msg[OScDev_MAX_STR_LEN + 1];
-        OScDev_Error_FormatRecursive(err, msg, sizeof(msg));
-        OScDev_Log_Error(device, msg);
-        StopScan(device);
+        LogRichError(device, err);
+        err = StopScan(device);
+        if (err)
+            LogRichError(device, err);
         goto finish;
     }
 
@@ -230,11 +261,26 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
         }
     }
 
-    StopScan(device);
+    err = StopScan(device);
+    if (err)
+        LogRichError(device, err);
 
-    ConfigureParkTiming(device, &GetImplData(device)->scannerConfig, acq);
-    WriteParkOutput(device, &GetImplData(device)->scannerConfig, acq);
-    GenerateParkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    err =
+        ConfigureParkTiming(device, &GetImplData(device)->scannerConfig, acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
+
+    err = WriteParkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
+
+    err = GenerateParkOutput(device, &GetImplData(device)->scannerConfig, acq);
+    if (err)
+        LogRichError(device, err);
 
 finish:
     EnterCriticalSection(&(GetImplData(device)->acquisition.mutex));

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -162,7 +162,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
     err = SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
     if (err) {
         LogRichError(device, err);
-        goto finish;
+        goto park;
     }
 
     GetImplData(device)->readBufferState = READ_BUFFER_IDLE;
@@ -183,7 +183,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
         err = StopScan(device);
         if (err)
             LogRichError(device, err);
-        goto finish;
+        goto park;
     }
 
     for (uint32_t frame = 0; frame < totalFrames; ++frame) {
@@ -264,6 +264,13 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
     err = StopScan(device);
     if (err)
         LogRichError(device, err);
+
+park:
+    err = CreateScannerTask(device, &GetImplData(device)->scannerConfig);
+    if (err) {
+        LogRichError(device, err);
+        goto finish;
+    }
 
     err =
         ConfigureParkTiming(device, &GetImplData(device)->scannerConfig, acq);

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -136,6 +136,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
     GetImplData(device)->frameAvailable = false;
     GetImplData(device)->framePixelsFilled = 0;
     GetImplData(device)->activeWriteBuffer = 0;
+    GetImplData(device)->consumerReading = false;
 
     double pixelRateHz = OScDev_Acquisition_GetPixelRate(acq);
     struct WaveformParams params;
@@ -184,6 +185,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             if (gotFrame) {
                 rb = GetImplData(device)->completedReadBuffer;
                 GetImplData(device)->frameAvailable = false;
+                GetImplData(device)->consumerReading = true;
             }
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
 
@@ -198,6 +200,10 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
                 OScDev_Acquisition_CallFrameCallback(
                     acq, ch, GetImplData(device)->frameBuffers[rb][ch]);
             }
+
+            EnterCriticalSection(&GetImplData(device)->frameMutex);
+            GetImplData(device)->consumerReading = false;
+            LeaveCriticalSection(&GetImplData(device)->frameMutex);
         } else {
             Sleep(estFrameTimeMs);
         }

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -362,8 +362,15 @@ OScDev_RichError *StartAcquisition(OScDev_Device *device) {
         return err;
 
     DWORD id;
-    GetImplData(device)->acquisition.thread =
-        CreateThread(NULL, 0, AcquisitionLoop, device, 0, &id);
+    HANDLE thread = CreateThread(NULL, 0, AcquisitionLoop, device, 0, &id);
+    if (!thread) {
+        EnterCriticalSection(&GetImplData(device)->acquisition.mutex);
+        GetImplData(device)->acquisition.started = false;
+        GetImplData(device)->acquisition.running = false;
+        LeaveCriticalSection(&GetImplData(device)->acquisition.mutex);
+        return OScDev_Error_Create("Failed to create acquisition thread");
+    }
+    CloseHandle(thread);
     return OScDev_RichError_OK;
 }
 

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -203,14 +203,28 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             }
 
             int nChans = GetNumberOfEnabledChannels(device);
+            bool ok = true;
             for (int ch = 0; ch < nChans; ++ch) {
-                OScDev_Acquisition_CallFrameCallback(
+                ok = OScDev_Acquisition_CallFrameCallback(
                     acq, ch, GetImplData(device)->frameBuffers[rb][ch]);
+                if (!ok) {
+                    break;
+                }
             }
 
+            // Mark buffer finished even if we fail (!ok), so that the producer
+            // thread (DAQmx callback) won't have a buffer overflow error in
+            // the meantime.
             EnterCriticalSection(&GetImplData(device)->frameMutex);
             GetImplData(device)->readBufferState = READ_BUFFER_IDLE;
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
+
+            if (!ok) {
+                OScDev_Log_Error(
+                    device,
+                    "Stopping acquisition because frame could not be transmitted");
+                break;
+            }
         } else {
             Sleep(estFrameTimeMs);
         }

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -167,21 +167,31 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
         OScDev_Log_Debug(device, msg);
 
         if (!GetImplData(device)->scannerOnly) {
-            uint32_t totalWaitTimeMs = 0;
+            int rb = 0;
+
+            EnterCriticalSection(&GetImplData(device)->frameMutex);
             while (!GetImplData(device)->oneFrameScanDone) {
-                Sleep(1);
-                totalWaitTimeMs += 1;
-                if (totalWaitTimeMs > 2 * estFrameTimeMs) {
-                    OScDev_Log_Error(device, "Error: Acquisition timeout!");
-                    break;
+                if (!SleepConditionVariableCS(&GetImplData(device)->frameReady,
+                                              &GetImplData(device)->frameMutex,
+                                              2 * estFrameTimeMs)) {
+                    break; // timeout
                 }
+                if (GetImplData(device)->acquisition.stopRequested)
+                    break;
             }
 
-            if (!GetImplData(device)->oneFrameScanDone)
-                break;
+            bool gotFrame = GetImplData(device)->oneFrameScanDone;
+            if (gotFrame) {
+                rb = GetImplData(device)->completedReadBuffer;
+                GetImplData(device)->oneFrameScanDone = false;
+            }
+            LeaveCriticalSection(&GetImplData(device)->frameMutex);
 
-            int rb = GetImplData(device)->completedReadBuffer;
-            GetImplData(device)->oneFrameScanDone = false;
+            if (!gotFrame) {
+                if (!GetImplData(device)->acquisition.stopRequested)
+                    OScDev_Log_Error(device, "Error: Acquisition timeout!");
+                break;
+            }
 
             int nChans = GetNumberOfEnabledChannels(device);
             for (int ch = 0; ch < nChans; ++ch) {
@@ -280,6 +290,7 @@ OScDev_RichError *StopAcquisitionAndWait(OScDev_Device *device) {
     EnterCriticalSection(mutex);
     if (GetImplData(device)->acquisition.started) {
         GetImplData(device)->acquisition.stopRequested = true;
+        WakeConditionVariable(&GetImplData(device)->frameReady);
     } else { // Armed but not started
         GetImplData(device)->acquisition.running = false;
     }

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -133,11 +133,10 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
 
     SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
 
-    GetImplData(device)->frameAvailable = false;
+    GetImplData(device)->readBufferState = READ_BUFFER_IDLE;
     GetImplData(device)->framePixelsFilled = 0;
     GetImplData(device)->rawDataSize = 0;
     GetImplData(device)->activeWriteBuffer = 0;
-    GetImplData(device)->consumerReading = false;
 
     double pixelRateHz = OScDev_Acquisition_GetPixelRate(acq);
     struct WaveformParams params;
@@ -172,7 +171,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             int rb = 0;
 
             EnterCriticalSection(&GetImplData(device)->frameMutex);
-            while (!GetImplData(device)->frameAvailable) {
+            while (GetImplData(device)->readBufferState != READ_BUFFER_READY) {
                 if (!SleepConditionVariableCS(&GetImplData(device)->frameReady,
                                               &GetImplData(device)->frameMutex,
                                               2 * estFrameTimeMs)) {
@@ -186,11 +185,11 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
                     break;
             }
 
-            bool gotFrame = GetImplData(device)->frameAvailable;
+            bool gotFrame =
+                GetImplData(device)->readBufferState == READ_BUFFER_READY;
             if (gotFrame) {
-                rb = GetImplData(device)->completedReadBuffer;
-                GetImplData(device)->frameAvailable = false;
-                GetImplData(device)->consumerReading = true;
+                rb = 1 - GetImplData(device)->activeWriteBuffer;
+                GetImplData(device)->readBufferState = READ_BUFFER_READING;
             }
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
 
@@ -210,7 +209,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             }
 
             EnterCriticalSection(&GetImplData(device)->frameMutex);
-            GetImplData(device)->consumerReading = false;
+            GetImplData(device)->readBufferState = READ_BUFFER_IDLE;
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
         } else {
             Sleep(estFrameTimeMs);

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -133,7 +133,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
 
     SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
 
-    GetImplData(device)->oneFrameScanDone = false;
+    GetImplData(device)->frameAvailable = false;
     GetImplData(device)->framePixelsFilled = 0;
     GetImplData(device)->activeWriteBuffer = 0;
 
@@ -170,7 +170,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             int rb = 0;
 
             EnterCriticalSection(&GetImplData(device)->frameMutex);
-            while (!GetImplData(device)->oneFrameScanDone) {
+            while (!GetImplData(device)->frameAvailable) {
                 if (!SleepConditionVariableCS(&GetImplData(device)->frameReady,
                                               &GetImplData(device)->frameMutex,
                                               2 * estFrameTimeMs)) {
@@ -180,10 +180,10 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
                     break;
             }
 
-            bool gotFrame = GetImplData(device)->oneFrameScanDone;
+            bool gotFrame = GetImplData(device)->frameAvailable;
             if (gotFrame) {
                 rb = GetImplData(device)->completedReadBuffer;
-                GetImplData(device)->oneFrameScanDone = false;
+                GetImplData(device)->frameAvailable = false;
             }
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
 

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -24,6 +24,11 @@ static OScDev_RichError *SetUpDAQ(OScDev_Device *device) {
     double zoomFactor = OScDev_Acquisition_GetZoomFactor(acq);
     uint32_t xOffset, yOffset, width, height;
     OScDev_Acquisition_GetROI(acq, &xOffset, &yOffset, &width, &height);
+    uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
+    if (totalFrames != GetImplData(device)->configuredTotalFrames) {
+        GetImplData(device)->clockConfig.mustReconfigureTiming = true;
+        GetImplData(device)->scannerConfig.mustReconfigureTiming = true;
+    }
     if (pixelRateHz != GetImplData(device)->configuredPixelRateHz) {
         GetImplData(device)->clockConfig.mustReconfigureTiming = true;
         GetImplData(device)->scannerConfig.mustReconfigureTiming = true;
@@ -69,6 +74,7 @@ static OScDev_RichError *SetUpDAQ(OScDev_Device *device) {
     resolution = OScDev_Acquisition_GetResolution(acq);
     zoomFactor = OScDev_Acquisition_GetZoomFactor(acq);
     OScDev_Acquisition_GetROI(acq, &xOffset, &yOffset, &width, &height);
+    GetImplData(device)->configuredTotalFrames = totalFrames;
     GetImplData(device)->configuredPixelRateHz = pixelRateHz;
     GetImplData(device)->configuredResolution = resolution;
     GetImplData(device)->configuredZoomFactor = zoomFactor;
@@ -191,7 +197,8 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
         goto park;
     }
 
-    for (uint32_t frame = 0; frame < totalFrames; ++frame) {
+    for (uint32_t frame = 0; totalFrames >= INT32_MAX || frame < totalFrames;
+         ++frame) {
         bool stopRequested;
         EnterCriticalSection(&(GetImplData(device)->acquisition.mutex));
         stopRequested = GetImplData(device)->acquisition.stopRequested;

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -12,7 +12,6 @@
 #include <NIDAQmx.h>
 #include <OpenScanDeviceLib.h>
 
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -101,56 +100,14 @@ static OScDev_RichError *StartScan(OScDev_Device *device) {
     return OScDev_RichError_OK;
 }
 
-static OScDev_RichError *WaitScanToFinish(OScDev_Device *device,
-                                          OScDev_Acquisition *acq) {
-    double pixelRateHz = OScDev_Acquisition_GetPixelRate(acq);
-    struct WaveformParams parameters;
-    SetWaveformParamsFromDevice(device, &parameters, acq);
-
-    // When scanRate is low, it takes longer to finish generating scan
-    // waveform. Since acquisition only takes a portion of the total scan time,
-    // it may occur that waveform task is stopped right after acquisition is
-    // done but the waveform generation is not done yet -- thus nierr 200010:
-    // "Finite acquisition or generation has been stopped before the requested
-    // number of samples were acquired or generated." So need to wait some
-    // miliseconds till waveform generation is done before stop the task.
-    double yRetraceTime =
-        GetScannerWaveformSizeAfterLastPixel(&parameters) / pixelRateHz;
-    double estFrameTime = GetScannerWaveformSize(&parameters) / pixelRateHz;
-    double secondsToWait =
-        GetImplData(device)->scannerOnly ? estFrameTime : yRetraceTime;
-    char msg[OScDev_MAX_STR_LEN + 1];
-    snprintf(msg, OScDev_MAX_STR_LEN, "Wait %f s for scan to finish...",
-             secondsToWait);
-    OScDev_Log_Debug(device, msg);
-    Sleep((DWORD)ceil(secondsToWait * 1000));
-
-    return OScDev_RichError_OK;
-}
-
-static OScDev_RichError *StopScan(OScDev_Device *device,
-                                  OScDev_Acquisition *acq) {
+static OScDev_RichError *StopScan(OScDev_Device *device) {
     OScDev_RichError *err, *lastErr = OScDev_RichError_OK;
-
-    // Stopping a task may return an error if it failed, so make sure to stop
-    // all tasks even if we get errors.
 
     if (!GetImplData(device)->scannerOnly) {
         err = StopDetector(&GetImplData(device)->detectorConfig);
         if (err)
             lastErr = err;
     }
-
-    // When scanRate is low, it takes longer to finish generating scan
-    // waveform. Since acquisition only takes a portion of the total scan time,
-    // it may occur that waveform task is stopped right after acquisition is
-    // done but the waveform generation is not done yet -- thus nierr 200010:
-    // "Finite acquisition or generation has been stopped before the requested
-    // number of samples were acquired or generated." So need to wait some
-    // miliseconds till waveform generation is done before stop the task.
-    err = WaitScanToFinish(device, acq);
-    if (err)
-        return err;
 
     err = StopClock(&GetImplData(device)->clockConfig);
     if (err)
@@ -163,81 +120,39 @@ static OScDev_RichError *StopScan(OScDev_Device *device,
     return lastErr;
 }
 
-static OScDev_RichError *AcquireFrame(OScDev_Device *device,
-                                      OScDev_Acquisition *acq) {
-    double pixelRateHz = OScDev_Acquisition_GetPixelRate(acq);
-    struct WaveformParams params;
-    SetWaveformParamsFromDevice(device, &params, acq);
-    GetImplData(device)->oneFrameScanDone = false;
-    GetImplData(device)->framePixelsFilled = 0;
-
-    uint32_t totalElementsPerFramePerChan = GetScannerWaveformSize(&params);
-    uint32_t estFrameTimeMs =
-        (uint32_t)(1e3 * totalElementsPerFramePerChan / pixelRateHz);
-    uint32_t totalWaitTimeMs = 0;
-
-    OScDev_RichError *err;
-    err = StartScan(device);
-    if (err)
-        return err;
-
-    // Wait for scan to complete
-    err = CreateDAQmxError(DAQmxWaitUntilTaskDone(
-        GetImplData(device)->scannerConfig.aoTask, 2 * estFrameTimeMs * 1e-3));
-    if (err) {
-        err = OScDev_Error_Wrap(err,
-                                "Failed to wait for scanner task to finish");
-        return err;
-    }
-
-    // Wait for data
-    if (!GetImplData(device)->scannerOnly) {
-        while (!GetImplData(device)->oneFrameScanDone) {
-            Sleep(1);
-            totalWaitTimeMs += 1;
-            if (totalWaitTimeMs > 2 * estFrameTimeMs) {
-                OScDev_Log_Error(device, "Error: Acquisition timeout!");
-                break;
-            }
-        }
-        char msg[OScDev_MAX_STR_LEN + 1];
-        snprintf(msg, OScDev_MAX_STR_LEN, "Total wait time is %d ",
-                 totalWaitTimeMs);
-        OScDev_Log_Debug(device, msg);
-    }
-
-    err = StopScan(device, acq);
-    if (err)
-        return err;
-
-    if (!GetImplData(device)->scannerOnly) {
-        int nChans = GetNumberOfEnabledChannels(device);
-        for (int ch = 0; ch < nChans; ++ch) {
-            bool shouldContinue = OScDev_Acquisition_CallFrameCallback(
-                acq, ch, GetImplData(device)->frameBuffers[ch]);
-            if (!shouldContinue) {
-                // TODO Stop acquisition
-            }
-        }
-    }
-
-    return OScDev_RichError_OK;
-}
-
 static DWORD WINAPI AcquisitionLoop(void *param) {
     OScDev_Device *device = (OScDev_Device *)param;
     OScDev_Acquisition *acq = GetImplData(device)->acquisition.acquisition;
 
     uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
 
-    // insert from parking to start here
     CreateScannerTask(device, &GetImplData(device)->scannerConfig);
     ConfigureUnparkTiming(device, &GetImplData(device)->scannerConfig, acq);
     WriteUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
     GenerateUnparkOutput(device, &GetImplData(device)->scannerConfig, acq);
 
-    // prepare raster waveform
     SetUpScanner(device, &GetImplData(device)->scannerConfig, acq);
+
+    GetImplData(device)->oneFrameScanDone = false;
+    GetImplData(device)->framePixelsFilled = 0;
+    GetImplData(device)->activeWriteBuffer = 0;
+
+    double pixelRateHz = OScDev_Acquisition_GetPixelRate(acq);
+    struct WaveformParams params;
+    SetWaveformParamsFromDevice(device, &params, acq);
+    uint32_t totalElementsPerFramePerChan = GetScannerWaveformSize(&params);
+    uint32_t estFrameTimeMs =
+        (uint32_t)(1e3 * totalElementsPerFramePerChan / pixelRateHz);
+
+    OScDev_RichError *err;
+    err = StartScan(device);
+    if (err) {
+        char msg[OScDev_MAX_STR_LEN + 1];
+        OScDev_Error_FormatRecursive(err, msg, sizeof(msg));
+        OScDev_Log_Error(device, msg);
+        StopScan(device);
+        goto finish;
+    }
 
     for (uint32_t frame = 0; frame < totalFrames; ++frame) {
         bool stopRequested;
@@ -248,25 +163,43 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
             break;
 
         char msg[OScDev_MAX_STR_LEN + 1];
-        snprintf(msg, OScDev_MAX_STR_LEN, "Sequence acquiring frame # %d",
-                 frame);
+        snprintf(msg, OScDev_MAX_STR_LEN, "Acquiring frame # %u", frame);
         OScDev_Log_Debug(device, msg);
 
-        OScDev_RichError *err;
-        err = AcquireFrame(device, acq);
-        if (err) {
-            err = OScDev_Error_Wrap(err, "Error during sequence acquisition");
-            OScDev_Error_FormatRecursive(err, msg, sizeof(msg));
-            OScDev_Log_Error(device, msg);
-            break;
+        if (!GetImplData(device)->scannerOnly) {
+            uint32_t totalWaitTimeMs = 0;
+            while (!GetImplData(device)->oneFrameScanDone) {
+                Sleep(1);
+                totalWaitTimeMs += 1;
+                if (totalWaitTimeMs > 2 * estFrameTimeMs) {
+                    OScDev_Log_Error(device, "Error: Acquisition timeout!");
+                    break;
+                }
+            }
+
+            if (!GetImplData(device)->oneFrameScanDone)
+                break;
+
+            int rb = GetImplData(device)->completedReadBuffer;
+            GetImplData(device)->oneFrameScanDone = false;
+
+            int nChans = GetNumberOfEnabledChannels(device);
+            for (int ch = 0; ch < nChans; ++ch) {
+                OScDev_Acquisition_CallFrameCallback(
+                    acq, ch, GetImplData(device)->frameBuffers[rb][ch]);
+            }
+        } else {
+            Sleep(estFrameTimeMs);
         }
     }
 
-    // insert from start to parking here
+    StopScan(device);
+
     ConfigureParkTiming(device, &GetImplData(device)->scannerConfig, acq);
     WriteParkOutput(device, &GetImplData(device)->scannerConfig, acq);
     GenerateParkOutput(device, &GetImplData(device)->scannerConfig, acq);
 
+finish:
     EnterCriticalSection(&(GetImplData(device)->acquisition.mutex));
     GetImplData(device)->acquisition.running = false;
     LeaveCriticalSection(&(GetImplData(device)->acquisition.mutex));

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -91,13 +91,21 @@ static OScDev_RichError *StartScan(OScDev_Device *device) {
 
     err = StartClock(&GetImplData(device)->clockConfig);
     if (err)
-        return err;
+        goto stop_detector;
 
     err = StartScanner(&GetImplData(device)->scannerConfig);
     if (err)
-        return err;
+        goto stop_clock;
 
     return OScDev_RichError_OK;
+
+stop_clock:
+    OScDev_Error_Destroy(StopClock(&GetImplData(device)->clockConfig));
+stop_detector:
+    if (!GetImplData(device)->scannerOnly)
+        OScDev_Error_Destroy(
+            StopDetector(&GetImplData(device)->detectorConfig));
+    return err;
 }
 
 static OScDev_RichError *StopScan(OScDev_Device *device) {
@@ -180,9 +188,6 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
     err = StartScan(device);
     if (err) {
         LogRichError(device, err);
-        err = StopScan(device);
-        if (err)
-            LogRichError(device, err);
         goto park;
     }
 

--- a/src/Acquisition.c
+++ b/src/Acquisition.c
@@ -135,6 +135,7 @@ static DWORD WINAPI AcquisitionLoop(void *param) {
 
     GetImplData(device)->frameAvailable = false;
     GetImplData(device)->framePixelsFilled = 0;
+    GetImplData(device)->rawDataSize = 0;
     GetImplData(device)->activeWriteBuffer = 0;
     GetImplData(device)->consumerReading = false;
 

--- a/src/Clock.c
+++ b/src/Clock.c
@@ -93,10 +93,26 @@ static OScDev_RichError *ConfigureClockTiming(OScDev_Device *device,
     int32 elementsPerFramePerChan = GetClockWaveformSize(&params);
     uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
 
-    uInt64 totalDOSamples = (uInt64)totalFrames * elementsPerFramePerChan;
-    err = CreateDAQmxError(DAQmxCfgSampClkTiming(
-        config->doTask, "", pixelRateHz, DAQmx_Val_Rising,
-        DAQmx_Val_FiniteSamps, totalDOSamples));
+    int sampleMode;
+    if (totalFrames >= INT32_MAX) {
+        sampleMode = DAQmx_Val_ContSamps;
+    } else {
+        sampleMode = DAQmx_Val_FiniteSamps;
+    }
+
+    uInt64 doSamplesPerChan;
+    if (sampleMode == DAQmx_Val_ContSamps) {
+        doSamplesPerChan = elementsPerFramePerChan;
+    } else {
+        uInt64 totalDOSamples = (uInt64)totalFrames * elementsPerFramePerChan;
+        if (totalDOSamples > UINT32_MAX)
+            return OScDev_Error_Create(
+                "Total clock DO samples exceed maximum for finite mode");
+        doSamplesPerChan = totalDOSamples;
+    }
+    err = CreateDAQmxError(
+        DAQmxCfgSampClkTiming(config->doTask, "", pixelRateHz,
+                              DAQmx_Val_Rising, sampleMode, doSamplesPerChan));
     if (err) {
         err = OScDev_Error_Wrap(
             err, "Failed to configure timing for clock do task");
@@ -138,9 +154,18 @@ static OScDev_RichError *ConfigureClockTiming(OScDev_Device *device,
         return err;
     }
 
-    uInt64 totalCtrPulses = (uInt64)totalFrames * height;
+    uInt64 ctrSamplesPerChan;
+    if (sampleMode == DAQmx_Val_ContSamps) {
+        ctrSamplesPerChan = height;
+    } else {
+        uInt64 totalCtrPulses = (uInt64)totalFrames * height;
+        if (totalCtrPulses > UINT32_MAX)
+            return OScDev_Error_Create(
+                "Total clock counter pulses exceed maximum for finite mode");
+        ctrSamplesPerChan = totalCtrPulses;
+    }
     err = CreateDAQmxError(DAQmxCfgImplicitTiming(
-        config->lineCtrTask, DAQmx_Val_FiniteSamps, totalCtrPulses));
+        config->lineCtrTask, sampleMode, ctrSamplesPerChan));
     if (err) {
         err = OScDev_Error_Wrap(
             err, "Failed to configure timing for clock lineCtr");

--- a/src/Clock.c
+++ b/src/Clock.c
@@ -223,8 +223,7 @@ static OScDev_RichError *WriteClockOutput(OScDev_Device *device,
         goto cleanup;
     }
     if (numWritten != elementsPerFramePerChan) {
-        err =
-            OScDev_Error_Wrap(err, "Failed to write complete clock waveform");
+        err = OScDev_Error_Create("Failed to write complete clock waveform");
         goto cleanup;
     }
 

--- a/src/Clock.c
+++ b/src/Clock.c
@@ -91,13 +91,23 @@ static OScDev_RichError *ConfigureClockTiming(OScDev_Device *device,
 
     uint32_t elementsPerLine = GetLineWaveformSize(&params);
     int32 elementsPerFramePerChan = GetClockWaveformSize(&params);
+    uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
 
+    uInt64 totalDOSamples = (uInt64)totalFrames * elementsPerFramePerChan;
     err = CreateDAQmxError(DAQmxCfgSampClkTiming(
         config->doTask, "", pixelRateHz, DAQmx_Val_Rising,
-        DAQmx_Val_FiniteSamps, elementsPerFramePerChan));
+        DAQmx_Val_FiniteSamps, totalDOSamples));
     if (err) {
         err = OScDev_Error_Wrap(
             err, "Failed to configure timing for clock do task");
+        return err;
+    }
+
+    err = CreateDAQmxError(
+        DAQmxSetWriteRegenMode(config->doTask, DAQmx_Val_AllowRegen));
+    if (err) {
+        err = OScDev_Error_Wrap(err,
+                                "Failed to set regen mode for clock do task");
         return err;
     }
 
@@ -128,8 +138,9 @@ static OScDev_RichError *ConfigureClockTiming(OScDev_Device *device,
         return err;
     }
 
+    uInt64 totalCtrPulses = (uInt64)totalFrames * height;
     err = CreateDAQmxError(DAQmxCfgImplicitTiming(
-        config->lineCtrTask, DAQmx_Val_FiniteSamps, height));
+        config->lineCtrTask, DAQmx_Val_FiniteSamps, totalCtrPulses));
     if (err) {
         err = OScDev_Error_Wrap(
             err, "Failed to configure timing for clock lineCtr");
@@ -153,14 +164,6 @@ static OScDev_RichError *ConfigureClockTriggers(OScDev_Device *device,
         ss8_destroy(&trigSrc);
         err = OScDev_Error_Wrap(
             err, "Failed to configure trigger for clock do task");
-        return err;
-    }
-
-    err = CreateDAQmxError(DAQmxSetStartTrigRetriggerable(config->doTask, 1));
-    if (err) {
-        ss8_destroy(&trigSrc);
-        err = OScDev_Error_Wrap(err,
-                                "Failed to set retriggerable clock do task");
         return err;
     }
 

--- a/src/Detector.c
+++ b/src/Detector.c
@@ -111,6 +111,7 @@ static int32 HandleRawData(OScDev_Device *device) {
 
         GetImplData(device)->framePixelsFilled++;
         if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
+            EnterCriticalSection(&GetImplData(device)->frameMutex);
             if (GetImplData(device)->oneFrameScanDone) {
                 OScDev_Log_Warning(
                     device,
@@ -122,6 +123,8 @@ static int32 HandleRawData(OScDev_Device *device) {
                 1 - GetImplData(device)->activeWriteBuffer;
             GetImplData(device)->framePixelsFilled = 0;
             GetImplData(device)->oneFrameScanDone = true;
+            LeaveCriticalSection(&GetImplData(device)->frameMutex);
+            WakeConditionVariable(&GetImplData(device)->frameReady);
         }
     }
 

--- a/src/Detector.c
+++ b/src/Detector.c
@@ -112,7 +112,7 @@ static int32 HandleRawData(OScDev_Device *device) {
         GetImplData(device)->framePixelsFilled++;
         if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
             EnterCriticalSection(&GetImplData(device)->frameMutex);
-            if (GetImplData(device)->oneFrameScanDone) {
+            if (GetImplData(device)->frameAvailable) {
                 OScDev_Log_Warning(
                     device,
                     "Frame dropped: main thread did not consume previous frame");
@@ -122,7 +122,7 @@ static int32 HandleRawData(OScDev_Device *device) {
             GetImplData(device)->activeWriteBuffer =
                 1 - GetImplData(device)->activeWriteBuffer;
             GetImplData(device)->framePixelsFilled = 0;
-            GetImplData(device)->oneFrameScanDone = true;
+            GetImplData(device)->frameAvailable = true;
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
             WakeConditionVariable(&GetImplData(device)->frameReady);
         }

--- a/src/Detector.c
+++ b/src/Detector.c
@@ -112,6 +112,13 @@ static int32 HandleRawData(OScDev_Device *device) {
         GetImplData(device)->framePixelsFilled++;
         if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
             EnterCriticalSection(&GetImplData(device)->frameMutex);
+            if (GetImplData(device)->consumerReading) {
+                OScDev_Log_Error(
+                    device,
+                    "Buffer overrun: consumer still reading frame buffer");
+                LeaveCriticalSection(&GetImplData(device)->frameMutex);
+                return OScDev_Error_Unknown;
+            }
             if (GetImplData(device)->frameAvailable) {
                 OScDev_Log_Warning(
                     device,

--- a/src/Detector.c
+++ b/src/Detector.c
@@ -112,24 +112,17 @@ static int32 HandleRawData(OScDev_Device *device) {
         GetImplData(device)->framePixelsFilled++;
         if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
             EnterCriticalSection(&GetImplData(device)->frameMutex);
-            if (GetImplData(device)->consumerReading) {
+            if (GetImplData(device)->readBufferState != READ_BUFFER_IDLE) {
                 OScDev_Log_Error(
                     device,
-                    "Buffer overrun: consumer still reading frame buffer");
+                    "Buffer overrun: previous frame could not be transmitted in time");
                 LeaveCriticalSection(&GetImplData(device)->frameMutex);
                 return OScDev_Error_Unknown;
             }
-            if (GetImplData(device)->frameAvailable) {
-                OScDev_Log_Warning(
-                    device,
-                    "Frame dropped: main thread did not consume previous frame");
-            }
-            GetImplData(device)->completedReadBuffer =
-                GetImplData(device)->activeWriteBuffer;
             GetImplData(device)->activeWriteBuffer =
                 1 - GetImplData(device)->activeWriteBuffer;
             GetImplData(device)->framePixelsFilled = 0;
-            GetImplData(device)->frameAvailable = true;
+            GetImplData(device)->readBufferState = READ_BUFFER_READY;
             LeaveCriticalSection(&GetImplData(device)->frameMutex);
             WakeConditionVariable(&GetImplData(device)->frameReady);
         }

--- a/src/Detector.c
+++ b/src/Detector.c
@@ -74,10 +74,18 @@ static int32 HandleRawData(OScDev_Device *device) {
     // | ch0_samp0 ch1_samp0 ch0_samp1 ch1_samp1 | ch0_samp0 ...
     // We need to transfer this into per-channel frame buffers.
 
+    // TODO Cleaner to get raster size from the OScDev_Acquisition (a future
+    // OpenScanLib should allow getting the current device from the
+    // acquisition, so that we can pass the acquisition as callback data)
+    uint32_t pixelsPerLine = GetImplData(device)->configuredRasterWidth;
+    uint32_t linesPerFrame = GetImplData(device)->configuredRasterHeight;
+    size_t pixelsPerFrame = pixelsPerLine * linesPerFrame;
+
     // Process raw data and fill in frame buffers
     for (size_t p = 0; p < pixelsToProducePerChan; ++p) {
         size_t rawPixelStart = p * numChannels;
-        size_t pixelIndex = GetImplData(device)->framePixelsFilled++;
+        size_t pixelIndex = GetImplData(device)->framePixelsFilled;
+        int wb = GetImplData(device)->activeWriteBuffer;
 
         for (size_t ch = 0; ch < numChannels; ++ch) {
             size_t rawChannelStart = rawPixelStart + ch;
@@ -98,7 +106,22 @@ static int32 HandleRawData(OScDev_Device *device) {
             }
             uint16_t pixel = (uint16_t)dpixel;
 
-            GetImplData(device)->frameBuffers[ch][pixelIndex] = pixel;
+            GetImplData(device)->frameBuffers[wb][ch][pixelIndex] = pixel;
+        }
+
+        GetImplData(device)->framePixelsFilled++;
+        if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
+            if (GetImplData(device)->oneFrameScanDone) {
+                OScDev_Log_Warning(
+                    device,
+                    "Frame dropped: main thread did not consume previous frame");
+            }
+            GetImplData(device)->completedReadBuffer =
+                GetImplData(device)->activeWriteBuffer;
+            GetImplData(device)->activeWriteBuffer =
+                1 - GetImplData(device)->activeWriteBuffer;
+            GetImplData(device)->framePixelsFilled = 0;
+            GetImplData(device)->oneFrameScanDone = true;
         }
     }
 
@@ -108,26 +131,10 @@ static int32 HandleRawData(OScDev_Device *device) {
             sizeof(float64) * leftoverSamples);
     GetImplData(device)->rawDataSize = leftoverSamples;
 
-    // TODO Cleaner to get raster size from the OScDev_Acquisition (a future
-    // OpenScanLib should allow getting the current device from the
-    // acquisition, so that we can pass the acquisition as callback data)
-    uint32_t pixelsPerLine = GetImplData(device)->configuredRasterWidth;
-    uint32_t linesPerFrame = GetImplData(device)->configuredRasterHeight;
-
-    size_t pixelsPerFrame = pixelsPerLine * linesPerFrame;
     char msg[OScDev_MAX_STR_LEN + 1];
     snprintf(msg, OScDev_MAX_STR_LEN, "Read %zd pixels",
              GetImplData(device)->framePixelsFilled);
     OScDev_Log_Debug(device, msg);
-
-    if (GetImplData(device)->framePixelsFilled == pixelsPerFrame) {
-        // TODO This method of communication is unreliable without a mutex
-        // TODO But we should use a condition variable in any case
-        GetImplData(device)->oneFrameScanDone = true;
-
-        // TODO This reset should occur at start of frame
-        GetImplData(device)->framePixelsFilled = 0;
-    }
 
     return OScDev_OK;
 }
@@ -343,17 +350,18 @@ ConfigureDetectorCallback(OScDev_Device *device, struct DetectorConfig *config,
         realloc(GetImplData(device)->rawDataBuffer,
                 sizeof(float64) * GetImplData(device)->rawDataCapacity);
 
-    // Allocate frame buffers for the enabled channels
-    for (uint32_t ch = 0; ch < numChannels; ++ch) {
-        GetImplData(device)->frameBuffers[ch] =
-            realloc(GetImplData(device)->frameBuffers[ch],
-                    sizeof(uint16_t) * pixelsPerFrame);
+    for (int buf = 0; buf < 2; ++buf) {
+        for (uint32_t ch = 0; ch < numChannels; ++ch) {
+            GetImplData(device)->frameBuffers[buf][ch] =
+                realloc(GetImplData(device)->frameBuffers[buf][ch],
+                        sizeof(uint16_t) * pixelsPerFrame);
+        }
+        for (uint32_t ch = numChannels; ch < MAX_PHYSICAL_CHANS; ++ch) {
+            free(GetImplData(device)->frameBuffers[buf][ch]);
+            GetImplData(device)->frameBuffers[buf][ch] = NULL;
+        }
     }
-    // Free the frame buffers for unused channels
-    for (uint32_t ch = numChannels; ch < MAX_PHYSICAL_CHANS; ++ch) {
-        free(GetImplData(device)->frameBuffers[ch]);
-        GetImplData(device)->frameBuffers[ch] = NULL;
-    }
+    GetImplData(device)->activeWriteBuffer = 0;
 
     // Set DAQmxRead*() with DAQmx_Val_Auto to immediately return all
     // available samples instead of waiting for the requested number of

--- a/src/DeviceImplData.c
+++ b/src/DeviceImplData.c
@@ -24,6 +24,9 @@ void InitializeImplData(struct DeviceImplData *data) {
     ss8_init(&data->aiPhysChans);
     data->channelEnabled[0] = true;
 
+    InitializeCriticalSection(&data->frameMutex);
+    InitializeConditionVariable(&data->frameReady);
+
     InitializeCriticalSection(&(data->acquisition.mutex));
     InitializeConditionVariable(
         &(data->acquisition.acquisitionFinishCondition));

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -27,7 +27,7 @@ struct DeviceImplData {
     uint32_t configuredXOffset, configuredYOffset;
     uint32_t configuredRasterWidth, configuredRasterHeight;
 
-    bool oneFrameScanDone;
+    bool frameAvailable;
     bool scannerOnly;
 
     // counted as number of pixels.

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -27,6 +27,7 @@ struct DeviceImplData {
     struct ClockConfig clockConfig;
     struct ScannerConfig scannerConfig;
     struct DetectorConfig detectorConfig;
+    uint32_t configuredTotalFrames;
     double configuredPixelRateHz;
     uint32_t configuredResolution;
     double configuredZoomFactor;

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -67,6 +67,7 @@ struct DeviceImplData {
     uint16_t *frameBuffers[2][MAX_PHYSICAL_CHANS];
     int activeWriteBuffer;
     int completedReadBuffer;
+    bool consumerReading;
     size_t framePixelsFilled;
     CRITICAL_SECTION frameMutex;
     CONDITION_VARIABLE frameReady;

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -68,6 +68,8 @@ struct DeviceImplData {
     int activeWriteBuffer;
     int completedReadBuffer;
     size_t framePixelsFilled;
+    CRITICAL_SECTION frameMutex;
+    CONDITION_VARIABLE frameReady;
 
     struct {
         CRITICAL_SECTION mutex;

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -12,6 +12,12 @@
 
 #define MAX_PHYSICAL_CHANS 8
 
+enum ReadBufferState {
+    READ_BUFFER_IDLE,
+    READ_BUFFER_READY,
+    READ_BUFFER_READING,
+};
+
 // This struct holds the NIDAQ-specific device state and is associated with the
 // OpenScan device through the "impl data" mechanism.
 struct DeviceImplData {
@@ -27,7 +33,6 @@ struct DeviceImplData {
     uint32_t configuredXOffset, configuredYOffset;
     uint32_t configuredRasterWidth, configuredRasterHeight;
 
-    bool frameAvailable;
     bool scannerOnly;
 
     // counted as number of pixels.
@@ -66,8 +71,7 @@ struct DeviceImplData {
     // main thread (read). Index is order among currently enabled channels.
     uint16_t *frameBuffers[2][MAX_PHYSICAL_CHANS];
     int activeWriteBuffer;
-    int completedReadBuffer;
-    bool consumerReading;
+    enum ReadBufferState readBufferState;
     size_t framePixelsFilled;
     CRITICAL_SECTION frameMutex;
     CONDITION_VARIABLE frameReady;

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -61,10 +61,12 @@ struct DeviceImplData {
     size_t rawDataSize;     // Current data size
     size_t rawDataCapacity; // Buffer size
 
-    // Per-channel frame buffers that we fill in and pass to OpenScanLib
-    // Index is order among currently enabled channels.
-    // Buffers for unused channels may not be allocated.
-    uint16_t *frameBuffers[MAX_PHYSICAL_CHANS];
+    // Double-buffered per-channel frame buffers.
+    // [0] and [1] are alternated between the detector callback (write) and the
+    // main thread (read). Index is order among currently enabled channels.
+    uint16_t *frameBuffers[2][MAX_PHYSICAL_CHANS];
+    int activeWriteBuffer;
+    int completedReadBuffer;
     size_t framePixelsFilled;
 
     struct {

--- a/src/DeviceImplData.h
+++ b/src/DeviceImplData.h
@@ -78,7 +78,6 @@ struct DeviceImplData {
 
     struct {
         CRITICAL_SECTION mutex;
-        HANDLE thread;
         CONDITION_VARIABLE acquisitionFinishCondition;
         bool running;
         bool armed;         // Valid when running == true

--- a/src/OpenScanSettings.c
+++ b/src/OpenScanSettings.c
@@ -268,7 +268,7 @@ OScDev_Error NIDAQMakeSettings(OScDev_Device *device,
 
     err = EnumerateAIPhysChans(device);
     if (err)
-        OScDev_Error_ReturnAsCode(err);
+        return OScDev_Error_ReturnAsCode(err);
 
     *settings = OScDev_PtrArray_Create();
 

--- a/src/ParkUnpark.c
+++ b/src/ParkUnpark.c
@@ -76,8 +76,7 @@ OScDev_RichError *WriteUnparkOutput(OScDev_Device *device,
         goto cleanup;
     }
     if (numWritten != totalElementsPerFramePerChan) {
-        err =
-            OScDev_Error_Wrap(err, "Failed to write complete unpark waveform");
+        err = OScDev_Error_Create("Failed to write complete unpark waveform");
         goto cleanup;
     }
 
@@ -111,7 +110,7 @@ OScDev_RichError *WriteParkOutput(OScDev_Device *device,
         goto cleanup;
     }
     if (numWritten != totalElementsPerFramePerChan) {
-        err = OScDev_Error_Wrap(err, "Failed to write complete park waveform");
+        err = OScDev_Error_Create("Failed to write complete park waveform");
         goto cleanup;
     }
 

--- a/src/ParkUnpark.c
+++ b/src/ParkUnpark.c
@@ -149,6 +149,8 @@ OScDev_RichError *GenerateUnparkOutput(OScDev_Device *device,
     if (err) {
         err =
             OScDev_Error_Wrap(err, "Failed to wait for unpark task to finish");
+        DAQmxStopTask(config->aoTask);
+        ShutdownScanner(config);
         return err;
     }
 
@@ -190,6 +192,8 @@ OScDev_RichError *GenerateParkOutput(OScDev_Device *device,
         GetImplData(device)->scannerConfig.aoTask, maxWaitTimeMs * 1e-3));
     if (err) {
         err = OScDev_Error_Wrap(err, "Failed to wait for park task to finish");
+        DAQmxStopTask(config->aoTask);
+        ShutdownScanner(config);
         return err;
     }
 

--- a/src/Scanner.c
+++ b/src/Scanner.c
@@ -21,12 +21,21 @@ static OScDev_RichError *ConfigureScannerTiming(OScDev_Device *device,
     SetWaveformParamsFromDevice(device, &params, acq);
 
     int32 totalElementsPerFramePerChan = GetScannerWaveformSize(&params);
+    uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
+    uInt64 totalSamples = (uInt64)totalFrames * totalElementsPerFramePerChan;
 
     err = CreateDAQmxError(DAQmxCfgSampClkTiming(
         config->aoTask, "", pixelRateHz, DAQmx_Val_Rising,
-        DAQmx_Val_FiniteSamps, totalElementsPerFramePerChan));
+        DAQmx_Val_FiniteSamps, totalSamples));
     if (err) {
         err = OScDev_Error_Wrap(err, "Failed to configure timing for scanner");
+        return err;
+    }
+
+    err = CreateDAQmxError(
+        DAQmxSetWriteRegenMode(config->aoTask, DAQmx_Val_AllowRegen));
+    if (err) {
+        err = OScDev_Error_Wrap(err, "Failed to set regen mode for scanner");
         return err;
     }
 

--- a/src/Scanner.c
+++ b/src/Scanner.c
@@ -63,7 +63,7 @@ static OScDev_RichError *WriteScannerOutput(OScDev_Device *device,
         goto cleanup;
     }
     if (numWritten != totalElementsPerFramePerChan) {
-        err = OScDev_Error_Wrap(err, "Failed to write complete scan waveform");
+        err = OScDev_Error_Create("Failed to write complete scan waveform");
         goto cleanup;
     }
 

--- a/src/Scanner.c
+++ b/src/Scanner.c
@@ -9,6 +9,7 @@
 #include <OpenScanDeviceLib.h>
 #include <ss8str.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -22,11 +23,25 @@ static OScDev_RichError *ConfigureScannerTiming(OScDev_Device *device,
 
     int32 totalElementsPerFramePerChan = GetScannerWaveformSize(&params);
     uint32_t totalFrames = OScDev_Acquisition_GetNumberOfFrames(acq);
-    uInt64 totalSamples = (uInt64)totalFrames * totalElementsPerFramePerChan;
 
-    err = CreateDAQmxError(DAQmxCfgSampClkTiming(
-        config->aoTask, "", pixelRateHz, DAQmx_Val_Rising,
-        DAQmx_Val_FiniteSamps, totalSamples));
+    int sampleMode;
+    uInt64 samplesPerChan;
+    if (totalFrames >= INT32_MAX) {
+        sampleMode = DAQmx_Val_ContSamps;
+        samplesPerChan = totalElementsPerFramePerChan;
+    } else {
+        uInt64 totalSamples =
+            (uInt64)totalFrames * totalElementsPerFramePerChan;
+        if (totalSamples > UINT32_MAX)
+            return OScDev_Error_Create(
+                "Total scanner samples exceed maximum for finite mode");
+        sampleMode = DAQmx_Val_FiniteSamps;
+        samplesPerChan = totalSamples;
+    }
+
+    err = CreateDAQmxError(DAQmxCfgSampClkTiming(config->aoTask, "",
+                                                 pixelRateHz, DAQmx_Val_Rising,
+                                                 sampleMode, samplesPerChan));
     if (err) {
         err = OScDev_Error_Wrap(err, "Failed to configure timing for scanner");
         return err;


### PR DESCRIPTION
Closes #15.

Continuously scan multiple frames with no extra gap in between.

Also fix thread synchronization, which was missing.

There are still pauses between unpark/park and the raster scans.